### PR TITLE
Added SSN validation and fixed postcode validation for Belgium

### DIFF
--- a/libs/be_validation.php
+++ b/libs/be_validation.php
@@ -34,7 +34,38 @@ class BeValidation {
  * @access public
  */
 	function postal($check) {
-		$pattern = '/^[1-9]{1}[0-9]{3}$/';
+		$pattern = '/^[1-9]{1}[0-9]{3}|0612$/';
 		return preg_match($pattern, $check);
+	}
+
+/**
+ * Checks social security numbers (rijksregisternummer) for Belgium
+ * 
+ * Strict format is: ##.##.##-###.##
+ *
+ * @param string $check The value to check.
+ * @param bool $strictFormat Boolean to toggle strict format checking
+ * @return boolean
+ * @access public
+ */
+	function ssn($check, $strictFormat = true) {
+		if ($strictFormat && !preg_match('/[\d]{2}\.[\d]{2}\.[\d]{2}-[\d]{3}\.[\d]{2}/', $check)) {
+			return false;
+		}
+
+        $ssn = preg_replace('/\D/','',$check);
+        $controlDigits = substr($ssn, -2);
+        $principal = substr($ssn, 0, -2);
+
+		if (97 - ($principal % 97) == $controlDigits) {
+			return true;
+		}
+
+		$principal = '2' . $principal;
+		if (97 - ($principal % 97) == $controlDigits) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/tests/cases/libs/be_validation.test.php
+++ b/tests/cases/libs/be_validation.test.php
@@ -36,5 +36,30 @@ class BeValidationTestCase extends CakeTestCase {
 	function testPostal() {
 		$this->assertTrue(BeValidation::postal('1804'));
 		$this->assertFalse(BeValidation::postal('01804'));
+		$this->assertTrue(BeValidation::postal('0612'));
+	}
+
+/**
+ * test the ssn method of BeValidation
+ *
+ * @return void
+ * @access public
+ */
+	function testSsn() {
+		$this->assertTrue(BeValidation::ssn('72.02.02-900.81'));
+		$this->assertTrue(BeValidation::ssn('93.05.18-223.61'));
+		$this->assertTrue(BeValidation::ssn('00.01.25-567.77'));
+
+		$this->assertTrue(BeValidation::ssn('72020290081', false));
+		$this->assertTrue(BeValidation::ssn('93-05-18-223-61', false));
+		$this->assertTrue(BeValidation::ssn('00 01 25 567 77', false));
+
+		$this->assertFalse(BeValidation::ssn('72020290081'));
+		$this->assertFalse(BeValidation::ssn('93.05.18-223.60'));
+		$this->assertFalse(BeValidation::ssn('00.01.25-567.75'));
+
+		$this->assertFalse(BeValidation::ssn('72020290080', false));
+		$this->assertFalse(BeValidation::ssn('93-05-18-223-65', false));
+		$this->assertFalse(BeValidation::ssn('00 01 25 567 78', false));
 	}
 }


### PR DESCRIPTION
In Belgium there is a special postcode "0612" which was failing in the existing validation rule.

Also added a check function to validate social security numbers in belgium.
