### PR TITLE
Fix BrValidation::cpf for repeated digits

### DIFF
--- a/Lib/BrValidation.php
+++ b/Lib/BrValidation.php
@@ -70,13 +70,17 @@ class BrValidation {
 			return false;
 		}
 
-		if (!ctype_digit($check)) {
-			return false;
-		}
-
 		if (strlen($check) != 11) {
 			return false;
 		}
+		
+		// repeated values are invalid, but algorithms fails to check it
+		for($i = 0; $i < 10; $i++) {
+			if(str_repeat($i, 11) === $check) {
+				return false;
+			}
+		}
+		
 		$dv = substr($check, -2);
 		for ($pos = 9; $pos <= 10; $pos++) {
 			$sum = 0;

--- a/Test/Case/Lib/BrValidationTest.php
+++ b/Test/Case/Lib/BrValidationTest.php
@@ -78,6 +78,7 @@ class BrValidationTest extends CakeTestCase {
 		$this->assertFalse(BrValidation::cpf('50549727322'));
 		$this->assertFalse(BrValidation::cpf('869.283.422-11'));
 		$this->assertFalse(BrValidation::cpf('843.701.734-22'));
+		$this->assertFalse(BrValidation::cpf('999.999.999-99'));
 
 		$this->assertTrue(BrValidation::cpf('22692173813'));
 		$this->assertTrue(BrValidation::cpf('50549727302'));
@@ -121,5 +122,7 @@ class BrValidationTest extends CakeTestCase {
 		$this->assertFalse(BrValidation::ssn('33aaaa86000129'));
 		$this->assertFalse(BrValidation::ssn('22692173813xxx'));
 		$this->assertFalse(BrValidation::ssn('226921xxx73813'));
+		$this->assertFalse(BrValidation::ssn('11111111111'));
+		$this->assertFalse(BrValidation::cpf('abcdefghi'));
 	}
 }


### PR DESCRIPTION
Repeated digits are invalid in CPF number

Removed redundant ctype_check
