### PR TITLE
Phone numbers in Brazil have now a 9th digit

### DIFF
--- a/Test/Case/Validation/BrValidationTest.php
+++ b/Test/Case/Validation/BrValidationTest.php
@@ -40,6 +40,17 @@ class BrValidationTest extends CakeTestCase {
 		$this->assertFalse(BrValidation::phone('1-(33)-3-44'));
 		$this->assertFalse(BrValidation::phone('2345678'));
 
+		// with the wrong extra digit
+		$this->assertFalse(BrValidation::phone('55 (48) 12345 6789'));
+		$this->assertFalse(BrValidation::phone('+55 (48) 22345 6789'));
+		$this->assertFalse(BrValidation::phone('+55 (048) 32345 6789'));
+		$this->assertFalse(BrValidation::phone('+55 (48) 42345-6789'));
+		$this->assertFalse(BrValidation::phone('+55 (48) 52345.6789'));
+		$this->assertFalse(BrValidation::phone('(48) 12345 6789'));
+		$this->assertFalse(BrValidation::phone('22345 6789'));
+		$this->assertFalse(BrValidation::phone('32345.6789'));
+		$this->assertFalse(BrValidation::phone('423456789'));
+
 		$this->assertTrue(BrValidation::phone('55 (48) 2345 6789'));
 		$this->assertTrue(BrValidation::phone('+55 (48) 2345 6789'));
 		$this->assertTrue(BrValidation::phone('+55 (048) 2345 6789'));
@@ -50,7 +61,7 @@ class BrValidationTest extends CakeTestCase {
 		$this->assertTrue(BrValidation::phone('2345.6789'));
 		$this->assertTrue(BrValidation::phone('23456789'));
 
-		// with the extra digit
+		// // with the extra digit
 		$this->assertTrue(BrValidation::phone('55 (48) 92345 6789'));
 		$this->assertTrue(BrValidation::phone('+55 (48) 92345 6789'));
 		$this->assertTrue(BrValidation::phone('+55 (048) 92345 6789'));

--- a/Validation/BrValidation.php
+++ b/Validation/BrValidation.php
@@ -31,7 +31,7 @@ class BrValidation {
  * @return boolean
  */
 	public static function phone($check) {
-		return (bool)preg_match('/^(\+?\d{1,3}? ?)?(\(0?\d{2}\) ?)?\d{4,5}[-. ]?\d{4}$/', $check);
+		return (bool)preg_match('/^(\+?\d{1,3}? )?(\(0?\d{2}\) ?)?9?\d{4}[-. ]?\d{4}$/', $check);
 	}
 
 /**


### PR DESCRIPTION
UPDATED

Now, only the number 9 (nine) is accepted. Look at the DDI rule.. I had to remove the optionality to put a space after the number, 'cause it was accepting numbers like '12345-6512' (without the space, the \d{1,3} was allowing it).

xxxxxxxx

Hey, guys.. I was checking this plugin and I realized that it's only considering 8-digits numbers, but now São Paulo has 9-digits numbers. This rule will be applied to other states in Brazil soon, so I made the changes just to accept an extra digit.

News about this change: 
http://www.telegeography.com/products/commsupdate/articles/2012/07/30/anatel-adds-ninth-digit-to-sao-paulo-mobile-numbers-to-boost-capacity/

http://www.techtudo.com.br/artigos/noticia/2012/07/celulares-ganham-nono-digito-em-sao-paulo-saiba-tudo-sobre-mudanca.html
