### PR TITLE
Brazil now have 9-digit numbers for cell phones

### DIFF
--- a/Test/Case/Validation/BrValidationTest.php
+++ b/Test/Case/Validation/BrValidationTest.php
@@ -40,6 +40,14 @@ class BrValidationTest extends CakeTestCase {
 		$this->assertFalse(BrValidation::phone('1-(33)-3-44'));
 		$this->assertFalse(BrValidation::phone('2345678'));
 
+		// with the wrong extra digit
+		$this->assertFalse(BrValidation::phone('55 (48) 12345 6789'));
+		$this->assertFalse(BrValidation::phone('+55 (48) 22345 6789'));
+		$this->assertFalse(BrValidation::phone('+55 (048) 32345 6789'));
+		$this->assertFalse(BrValidation::phone('+55 (48) 42345-6789'));
+		$this->assertFalse(BrValidation::phone('+55 (48) 52345.6789'));
+		$this->assertFalse(BrValidation::phone('(48) 12345 6789'));
+
 		$this->assertTrue(BrValidation::phone('55 (48) 2345 6789'));
 		$this->assertTrue(BrValidation::phone('+55 (48) 2345 6789'));
 		$this->assertTrue(BrValidation::phone('+55 (048) 2345 6789'));
@@ -49,6 +57,17 @@ class BrValidationTest extends CakeTestCase {
 		$this->assertTrue(BrValidation::phone('2345-6789'));
 		$this->assertTrue(BrValidation::phone('2345.6789'));
 		$this->assertTrue(BrValidation::phone('23456789'));
+
+		// // with the extra digit
+		$this->assertTrue(BrValidation::phone('55 (48) 92345 6789'));
+		$this->assertTrue(BrValidation::phone('+55 (48) 92345 6789'));
+		$this->assertTrue(BrValidation::phone('+55 (048) 92345 6789'));
+		$this->assertTrue(BrValidation::phone('+55 (48) 92345-6789'));
+		$this->assertTrue(BrValidation::phone('+55 (48) 92345.6789'));
+		$this->assertTrue(BrValidation::phone('(48) 92345 6789'));
+		$this->assertTrue(BrValidation::phone('92345-6789'));
+		$this->assertTrue(BrValidation::phone('92345.6789'));
+		$this->assertTrue(BrValidation::phone('923456789'));
 	}
 
 /**

--- a/Validation/BrValidation.php
+++ b/Validation/BrValidation.php
@@ -31,7 +31,7 @@ class BrValidation {
  * @return boolean
  */
 	public static function phone($check) {
-		return (bool)preg_match('/^(\+?\d{1,3}? ?)?(\(0?\d{2}\) ?)?\d{4}[-. ]?\d{4}$/', $check);
+		return (bool)preg_match('/^(\+?\d{1,3}? ?)?(\(0?\d{2}\) ?)?9?\d{4}[-. ]?\d{4}$/', $check);
 	}
 
 /**


### PR DESCRIPTION
Hey, guys. According to Anatel, Brazil supports now 9-digit numbers in São Paulo (and soon in other states), so I made the changes to accept 9-digit numbers to cell phones in Brazil.

News about the change:

http://riotimesonline.com/brazil-news/rio-business/nine-digits-for-rio-cell-numbers-by-2015/
