### PR TITLE
Added ";" to the plural forms so cake will understand it

### DIFF
--- a/Locale/por/LC_MESSAGES/cake.po
+++ b/Locale/por/LC_MESSAGES/cake.po
@@ -8,7 +8,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: Portuguese\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 


### PR DESCRIPTION
A small fix, adding a ";" to the Plural forms line to match the check that's made in https://github.com/cakephp/cakephp/blob/master/lib/Cake/I18n/I18n.php#L257, method _pluralGuess
