### PR TITLE
Incorrect Plural-Forms

### DIFF
--- a/Locale/spa/LC_MESSAGES/cake.po
+++ b/Locale/spa/LC_MESSAGES/cake.po
@@ -8,7 +8,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: Spanish\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 


### PR DESCRIPTION
Plural Forms With out the trailing semicolon is not correctly identified by I18n::_pluralGuess()
