### PR TITLE
Fix composer install instrunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ensure `require` is present in `composer.json`. This will install the plugin int
 ```
 {
     "require": {
-        "cakephp/localized": "2.1.*"
+        "cakephp/localized": "2.1.x-dev"
     }
 }
 ```


### PR DESCRIPTION
A tag "2.1.x" doesn't exist at repository, so composer fail if specify "2.1.*" as a valid version.
The current correct map version is "2.1.x-dev", like described in composer.json file.
