### PR TITLE
Adding phone number verification, works with most australian numbers,...

### DIFF
--- a/Validation/AuValidation.php
+++ b/Validation/AuValidation.php
@@ -34,4 +34,14 @@ class AuValidation {
 		$pattern = '/^[0-9]{4}$/';
 		return (bool)preg_match($pattern, $check);
 	}
+/**
+ * Checks Phone Numbers for Australia w/o parentheses.
+ *
+ * @param string $check The value to check.
+ * @return boolean
+ */
+	public statuc function phone($check) {
+		$pattern = '/^(((0|\+61\s?)[2378])(\s|-)?\d{4}(\s|-)?\d{4}|((0|\+61\s?)4\d{2}|130?0?|1800|190[02])(\s|-)?\d{3}(\s|-)?\d{3})$/';
+		return (bool)preg_match($pattern, $check);
+	}
 }


### PR DESCRIPTION
... does not allow for parentheses.

Testing: http://regexpal.com/?flags=gm&regex=^%28%28%280|\%2B61\s%3F%29[2378]%29%28\s|-%29%3F\d{4}%28\s|-%29%3F\d{4}|%28%280|\%2B61\s%3F%294\d{2}|130%3F0%3F|1800|190[02]%29%28\s|-%29%3F\d{3}%28\s|-%29%3F\d{3}%29%24&input=0438833180%0A0394187400%0A03%205900%202961%0A0438%20833%20180%0A1300%20654%20677%0A%2B61%203%208624%202300%0A%2B61%20438%20833%20180%0A1800%20025%20952%0A1902%20515%20542%0A
