### PR TITLE
Fixed incorrect plural form in header....

### DIFF
--- a/Locale/fra/LC_MESSAGES/cake.po
+++ b/Locale/fra/LC_MESSAGES/cake.po
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-Language: French\n"
 "X-Poedit-Country: FRANCE\n"
-"Plural-Forms: nplurals=2; plural=(n==1? 0 : 1);\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: Controller/Scaffold.php:128
 msgid "Scaffold :: "


### PR DESCRIPTION
It seems like french plural form looks like this:
"Plural-Forms: nplurals=2; plural=(n==1? 0 : 1);\n"
But the correct value is:
"Plural-Forms: nplurals=2; plural=(n > 1);\n"

http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html
