### PR TITLE
update cake.pot with 2.6.1's version

### DIFF
--- a/Locale/cake.pot
+++ b/Locale/cake.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2012-12-19 18:18+0000\n"
+"POT-Creation-Date: 2015-01-19 07:43+0000\n"
 "PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
 "Last-Translator: NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
@@ -14,361 +14,387 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: Controller/Scaffold.php:128
-msgid "Scaffold :: "
+#: View/Errors/error400.ctp:19
+#: View/Errors/error500.ctp:19
+msgid "Error"
 msgstr ""
 
-#: Controller/Scaffold.php:167;234;305
-msgid "Invalid %s"
+#: View/Errors/error400.ctp:21
+msgid "The requested address %s was not found on this server."
 msgstr ""
 
-#: Controller/Scaffold.php:222
-msgid "updated"
-msgstr ""
-
-#: Controller/Scaffold.php:225
-msgid "saved"
-msgstr ""
-
-#: Controller/Scaffold.php:245
-msgid "The %1$s has been %2$s"
-msgstr ""
-
-#: Controller/Scaffold.php:256
-msgid "Please correct errors below."
-msgstr ""
-
-#: Controller/Scaffold.php:308
-msgid "The %1$s with id: %2$s has been deleted."
-msgstr ""
-
-#: Controller/Scaffold.php:311
-msgid "There was an error deleting the %1$s with id: %2$s"
-msgstr ""
-
-#: Controller/Component/AuthComponent.php:369
-msgid "You are not authorized to access that location."
-msgstr ""
-
-#: Error/ExceptionRenderer.php:209
-msgid "Not Found"
-msgstr ""
-
-#: Error/ExceptionRenderer.php:231
+#: View/Errors/error500.ctp:20
+#: Error/ExceptionRenderer.php:245
 msgid "An Internal Error Has Occurred."
 msgstr ""
 
-#: Model/Validator/CakeValidationSet.php:287
+#: Controller/Scaffold.php:127
+msgid "Scaffold :: "
+msgstr ""
+
+#: Controller/Scaffold.php:166;233;302
+msgid "Invalid %s"
+msgstr ""
+
+#: Controller/Scaffold.php:221
+msgid "updated"
+msgstr ""
+
+#: Controller/Scaffold.php:224
+msgid "saved"
+msgstr ""
+
+#: Controller/Scaffold.php:244
+msgid "The %1$s has been %2$s"
+msgstr ""
+
+#: Controller/Scaffold.php:254
+msgid "Please correct errors below."
+msgstr ""
+
+#: Controller/Scaffold.php:305
+msgid "The %1$s with id: %2$s has been deleted."
+msgstr ""
+
+#: Controller/Scaffold.php:308
+msgid "There was an error deleting the %1$s with id: %2$s"
+msgstr ""
+
+#: Controller/Component/AuthComponent.php:432
+msgid "You are not authorized to access that location."
+msgstr ""
+
+#: Error/ExceptionRenderer.php:222
+msgid "Not Found"
+msgstr ""
+
+#: Model/Validator/CakeValidationSet.php:286
 msgid "This field cannot be left blank"
 msgstr ""
 
-#: Network/CakeResponse.php:1222
+#: Network/CakeResponse.php:1355
 msgid "The requested file was not found"
 msgstr ""
 
-#: Utility/CakeNumber.php:101
-msgid "%d KB"
+#: Utility/CakeNumber.php:119
+msgid "%s KB"
 msgstr ""
 
-#: Utility/CakeNumber.php:103
-msgid "%.2f MB"
+#: Utility/CakeNumber.php:121
+msgid "%s MB"
 msgstr ""
 
-#: Utility/CakeNumber.php:105
-msgid "%.2f GB"
+#: Utility/CakeNumber.php:123
+msgid "%s GB"
 msgstr ""
 
-#: Utility/CakeNumber.php:107
-msgid "%.2f TB"
+#: Utility/CakeNumber.php:125
+msgid "%s TB"
 msgstr ""
 
-#: Utility/CakeNumber.php:99
+#: Utility/CakeNumber.php:117
 msgid "%d Byte"
 msgid_plural "%d Bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Utility/CakeTime.php:389
+#: Utility/CakeTime.php:397
 msgid "Today, %s"
 msgstr ""
 
-#: Utility/CakeTime.php:392
+#: Utility/CakeTime.php:400
 msgid "Yesterday, %s"
 msgstr ""
 
-#: Utility/CakeTime.php:395
+#: Utility/CakeTime.php:403
 msgid "Tomorrow, %s"
 msgstr ""
 
-#: Utility/CakeTime.php:400
+#: Utility/CakeTime.php:408
 msgid "Sunday"
 msgstr ""
 
-#: Utility/CakeTime.php:401
+#: Utility/CakeTime.php:409
 msgid "Monday"
 msgstr ""
 
-#: Utility/CakeTime.php:402
+#: Utility/CakeTime.php:410
 msgid "Tuesday"
 msgstr ""
 
-#: Utility/CakeTime.php:403
+#: Utility/CakeTime.php:411
 msgid "Wednesday"
 msgstr ""
 
-#: Utility/CakeTime.php:404
+#: Utility/CakeTime.php:412
 msgid "Thursday"
 msgstr ""
 
-#: Utility/CakeTime.php:405
+#: Utility/CakeTime.php:413
 msgid "Friday"
 msgstr ""
 
-#: Utility/CakeTime.php:406
+#: Utility/CakeTime.php:414
 msgid "Saturday"
 msgstr ""
 
-#: Utility/CakeTime.php:412
+#: Utility/CakeTime.php:420
 msgid "On %s %s"
 msgstr ""
 
-#: Utility/CakeTime.php:805
-msgid "just now"
-msgstr ""
-
-#: Utility/CakeTime.php:809
-msgid "on %s"
-msgstr ""
-
-#: Utility/CakeTime.php:853
+#: Utility/CakeTime.php:743
 msgid "%s ago"
 msgstr ""
 
-#: Utility/CakeTime.php:872;894
+#: Utility/CakeTime.php:744
+msgid "in %s"
+msgstr ""
+
+#: Utility/CakeTime.php:745
+msgid "on %s"
+msgstr ""
+
+#: Utility/CakeTime.php:801
+msgid "just now"
+msgstr ""
+
+#: Utility/CakeTime.php:924
+msgid "in about a second"
+msgstr ""
+
+#: Utility/CakeTime.php:925
+msgid "in about a minute"
+msgstr ""
+
+#: Utility/CakeTime.php:926
+msgid "in about an hour"
+msgstr ""
+
+#: Utility/CakeTime.php:927
+msgid "in about a day"
+msgstr ""
+
+#: Utility/CakeTime.php:928
+msgid "in about a week"
+msgstr ""
+
+#: Utility/CakeTime.php:929
+msgid "in about a year"
+msgstr ""
+
+#: Utility/CakeTime.php:933
+msgid "about a second ago"
+msgstr ""
+
+#: Utility/CakeTime.php:934
+msgid "about a minute ago"
+msgstr ""
+
+#: Utility/CakeTime.php:935
+msgid "about an hour ago"
+msgstr ""
+
+#: Utility/CakeTime.php:936
+msgid "about a day ago"
+msgstr ""
+
+#: Utility/CakeTime.php:937
+msgid "about a week ago"
+msgstr ""
+
+#: Utility/CakeTime.php:938
+msgid "about a year ago"
+msgstr ""
+
+#: Utility/CakeTime.php:958;980
 msgid "days"
 msgstr ""
 
-#: Utility/CakeTime.php:154
-msgid "abday"
-msgstr ""
-
-#: Utility/CakeTime.php:160
-msgid "day"
-msgstr ""
-
-#: Utility/CakeTime.php:166
-msgid "d_t_fmt"
-msgstr ""
-
-#: Utility/CakeTime.php:188
-msgid "abmon"
-msgstr ""
-
-#: Utility/CakeTime.php:194
-msgid "mon"
-msgstr ""
-
-#: Utility/CakeTime.php:205
-msgid "am_pm"
-msgstr ""
-
-#: Utility/CakeTime.php:212
-msgid "t_fmt_ampm"
-msgstr ""
-
-#: Utility/CakeTime.php:226
-msgid "d_fmt"
-msgstr ""
-
-#: Utility/CakeTime.php:232
-msgid "t_fmt"
-msgstr ""
-
-#: Utility/CakeTime.php:831
+#: Utility/CakeTime.php:895
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Utility/CakeTime.php:834
+#: Utility/CakeTime.php:898
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Utility/CakeTime.php:837
+#: Utility/CakeTime.php:901
 msgid "%d week"
 msgid_plural "%d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Utility/CakeTime.php:840
+#: Utility/CakeTime.php:904
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Utility/CakeTime.php:843
+#: Utility/CakeTime.php:907
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Utility/CakeTime.php:846
+#: Utility/CakeTime.php:910
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Utility/CakeTime.php:849
+#: Utility/CakeTime.php:913
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: View/Helper/FormHelper.php:681
+#: Utility/String.php:701
+msgid "and"
+msgstr ""
+
+#: View/Helper/FormHelper.php:732
 msgid "Error in field %s"
 msgstr ""
 
-#: View/Helper/FormHelper.php:868
-#: View/Scaffolds/form.ctp:48
-#: View/Scaffolds/index.ctp:79;94
-#: View/Scaffolds/view.ctp:66;81;192
+#: View/Helper/FormHelper.php:921
+#: View/Scaffolds/form.ctp:46
+#: View/Scaffolds/index.ctp:77;92
+#: View/Scaffolds/view.ctp:63;78;188
 msgid "New %s"
 msgstr ""
 
-#: View/Helper/FormHelper.php:874
-#: View/Scaffolds/view.ctp:54;113
+#: View/Helper/FormHelper.php:927
+#: View/Scaffolds/view.ctp:51;109
 msgid "Edit %s"
 msgstr ""
 
-#: View/Helper/FormHelper.php:1436
+#: View/Helper/FormHelper.php:1500
 msgid "empty"
 msgstr ""
 
-#: View/Helper/FormHelper.php:1796
-#: View/Scaffolds/form.ctp:23
+#: View/Helper/FormHelper.php:1895
+#: View/Scaffolds/form.ctp:21
 msgid "Submit"
 msgstr ""
 
-#: View/Helper/FormHelper.php:2704
+#: View/Helper/FormHelper.php:2874
 msgid "January"
 msgstr ""
 
-#: View/Helper/FormHelper.php:2705
+#: View/Helper/FormHelper.php:2875
 msgid "February"
 msgstr ""
 
-#: View/Helper/FormHelper.php:2706
+#: View/Helper/FormHelper.php:2876
 msgid "March"
 msgstr ""
 
-#: View/Helper/FormHelper.php:2707
+#: View/Helper/FormHelper.php:2877
 msgid "April"
 msgstr ""
 
-#: View/Helper/FormHelper.php:2708
+#: View/Helper/FormHelper.php:2878
 msgid "May"
 msgstr ""
 
-#: View/Helper/FormHelper.php:2709
+#: View/Helper/FormHelper.php:2879
 msgid "June"
 msgstr ""
 
-#: View/Helper/FormHelper.php:2710
+#: View/Helper/FormHelper.php:2880
 msgid "July"
 msgstr ""
 
-#: View/Helper/FormHelper.php:2711
+#: View/Helper/FormHelper.php:2881
 msgid "August"
 msgstr ""
 
-#: View/Helper/FormHelper.php:2712
+#: View/Helper/FormHelper.php:2882
 msgid "September"
 msgstr ""
 
-#: View/Helper/FormHelper.php:2713
+#: View/Helper/FormHelper.php:2883
 msgid "October"
 msgstr ""
 
-#: View/Helper/FormHelper.php:2714
+#: View/Helper/FormHelper.php:2884
 msgid "November"
 msgstr ""
 
-#: View/Helper/FormHelper.php:2715
+#: View/Helper/FormHelper.php:2885
 msgid "December"
 msgstr ""
 
-#: View/Helper/HtmlHelper.php:747
+#: View/Helper/HtmlHelper.php:782
 msgid "Home"
 msgstr ""
 
-#: View/Helper/PaginatorHelper.php:580
+#: View/Helper/PaginatorHelper.php:637
 msgid " of "
 msgstr ""
 
-#: View/Scaffolds/form.ctp:27
-#: View/Scaffolds/index.ctp:26;77
-#: View/Scaffolds/view.ctp:50
+#: View/Scaffolds/form.ctp:25
+#: View/Scaffolds/index.ctp:24;75
+#: View/Scaffolds/view.ctp:47
 msgid "Actions"
 msgstr ""
 
-#: View/Scaffolds/form.ctp:31
-#: View/Scaffolds/index.ctp:51
-#: View/Scaffolds/view.ctp:177
+#: View/Scaffolds/form.ctp:29
+#: View/Scaffolds/index.ctp:49
+#: View/Scaffolds/view.ctp:173
 msgid "Delete"
 msgstr ""
 
-#: View/Scaffolds/form.ctp:34
+#: View/Scaffolds/form.ctp:32
+#: View/Scaffolds/index.ctp:52
+#: View/Scaffolds/view.ctp:55;176
 msgid "Are you sure you want to delete # %s?"
 msgstr ""
 
-#: View/Scaffolds/form.ctp:37
+#: View/Scaffolds/form.ctp:35
 msgid "List"
 msgstr ""
 
-#: View/Scaffolds/form.ctp:44
-#: View/Scaffolds/index.ctp:87
-#: View/Scaffolds/view.ctp:62;75
+#: View/Scaffolds/form.ctp:42
+#: View/Scaffolds/index.ctp:85
+#: View/Scaffolds/view.ctp:59;72
 msgid "List %s"
 msgstr ""
 
-#: View/Scaffolds/index.ctp:48
-#: View/Scaffolds/view.ctp:165
+#: View/Scaffolds/index.ctp:46
+#: View/Scaffolds/view.ctp:161
 msgid "View"
 msgstr ""
 
-#: View/Scaffolds/index.ctp:49
-#: View/Scaffolds/view.ctp:171
+#: View/Scaffolds/index.ctp:47
+#: View/Scaffolds/view.ctp:167
 msgid "Edit"
 msgstr ""
 
-#: View/Scaffolds/index.ctp:54
-#: View/Scaffolds/view.ctp:58;180
-msgid "Are you sure you want to delete"
-msgstr ""
-
-#: View/Scaffolds/index.ctp:65
+#: View/Scaffolds/index.ctp:63
 msgid "Page {:page} of {:pages}, showing {:current} records out of {:count} total, starting on record {:start}, ending on {:end}"
 msgstr ""
 
-#: View/Scaffolds/index.ctp:70
+#: View/Scaffolds/index.ctp:68
 msgid "previous"
 msgstr ""
 
-#: View/Scaffolds/index.ctp:72
+#: View/Scaffolds/index.ctp:70
 msgid "next"
 msgstr ""
 
-#: View/Scaffolds/view.ctp:20
+#: View/Scaffolds/view.ctp:18
 msgid "View %s"
 msgstr ""
 
-#: View/Scaffolds/view.ctp:58
+#: View/Scaffolds/view.ctp:55
 msgid "Delete %s"
 msgstr ""
 
-#: View/Scaffolds/view.ctp:96;137
+#: View/Scaffolds/view.ctp:93;133
 msgid "Related %s"
 msgstr ""
-

--- a/Locale/cake_console.pot
+++ b/Locale/cake_console.pot
@@ -1,0 +1,2262 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2015-01-19 07:43+0000\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: Console/ConsoleErrorHandler.php:57
+msgid "<error>Error:</error> %s\n%s"
+msgstr ""
+
+#: Console/ConsoleErrorHandler.php:83
+msgid "%s in [%s, line %s]"
+msgstr ""
+
+#: Console/ConsoleErrorHandler.php:84
+msgid "<error>%s Error:</error> %s\n"
+msgstr ""
+
+#: Console/ConsoleInputArgument.php:98
+msgid " <comment>(optional)</comment>"
+msgstr ""
+
+#: Console/ConsoleInputArgument.php:101
+#: Console/ConsoleInputOption.php:130
+msgid " <comment>(choices: %s)</comment>"
+msgstr ""
+
+#: Console/ConsoleInputArgument.php:145
+msgid "\"%s\" is not a valid value for %s. Please use one of \"%s\""
+msgstr ""
+
+#: Console/ConsoleInputOption.php:95
+msgid "Short option \"%s\" is invalid, short options must be one letter."
+msgstr ""
+
+#: Console/ConsoleInputOption.php:127
+msgid " <comment>(default: %s)</comment>"
+msgstr ""
+
+#: Console/ConsoleInputOption.php:190
+msgid "\"%s\" is not a valid value for --%s. Please use one of \"%s\""
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:147
+msgid "Display this help."
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:154
+msgid "Enable verbose output."
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:158
+msgid "Enable quiet output."
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:493
+msgid "Missing required arguments. %s is required."
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:576
+msgid "Unknown short option `%s`"
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:592
+msgid "Unknown option `%s`"
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:645
+msgid "Too many arguments."
+msgstr ""
+
+#: Console/HelpFormatter.php:70
+msgid "<info>Usage:</info>"
+msgstr ""
+
+#: Console/HelpFormatter.php:75
+msgid "<info>Subcommands:</info>"
+msgstr ""
+
+#: Console/HelpFormatter.php:86
+msgid "To see help on a subcommand use <info>`cake %s [subcommand] --help`</info>"
+msgstr ""
+
+#: Console/HelpFormatter.php:93
+msgid "<info>Options:</info>"
+msgstr ""
+
+#: Console/HelpFormatter.php:108
+msgid "<info>Arguments:</info>"
+msgstr ""
+
+#: Console/Shell.php:240
+#: Console/Command/ServerShell.php:112
+msgid "<info>Welcome to CakePHP %s Console</info>"
+msgstr ""
+
+#: Console/Shell.php:242
+#: Console/Command/ServerShell.php:114
+msgid "App : %s"
+msgstr ""
+
+#: Console/Shell.php:243
+#: Console/Command/ServerShell.php:115
+#: Console/Command/Task/PluginTask.php:64
+#: Console/Command/Task/TestTask.php:112
+msgid "Path: %s"
+msgstr ""
+
+#: Console/Shell.php:706
+msgid "<error>Error:</error> %s"
+msgstr ""
+
+#: Console/Shell.php:744
+msgid "<warning>File `%s` exists</warning>"
+msgstr ""
+
+#: Console/Shell.php:745
+msgid "Do you want to overwrite?"
+msgstr ""
+
+#: Console/Shell.php:748
+msgid "<error>Quitting</error>."
+msgstr ""
+
+#: Console/Shell.php:751
+msgid "Skip `%s`"
+msgstr ""
+
+#: Console/Shell.php:755
+msgid "Creating file %s"
+msgstr ""
+
+#: Console/Shell.php:762
+msgid "<success>Wrote</success> `%s`"
+msgstr ""
+
+#: Console/Shell.php:766
+msgid "<error>Could not write to `%s`</error>."
+msgstr ""
+
+#: Console/Shell.php:786
+msgid "PHPUnit is not installed. Do you want to bake unit test files anyway?"
+msgstr ""
+
+#: Console/Shell.php:792
+msgid "You can download PHPUnit from %s"
+msgstr ""
+
+#: Console/Command/AclShell.php:77
+msgid "Error: Your current CakePHP configuration is set to an ACL implementation other than DB."
+msgstr ""
+
+#: Console/Command/AclShell.php:78
+msgid "Please change your core config to reflect your decision to use DbAcl before attempting to use this script"
+msgstr ""
+
+#: Console/Command/AclShell.php:80
+msgid "Current ACL Classname: %s"
+msgstr ""
+
+#: Console/Command/AclShell.php:88
+#: Console/Command/BakeShell.php:88
+#: Console/Command/I18nShell.php:54
+msgid "Your database configuration was not found. Take a moment to create one."
+msgstr ""
+
+#: Console/Command/AclShell.php:133
+msgid "/ can not be used as an alias!"
+msgstr ""
+
+#: Console/Command/AclShell.php:133
+msgid "\t/ is the root, please supply a sub alias"
+msgstr ""
+
+#: Console/Command/AclShell.php:139
+msgid "<success>New %s</success> '%s' created."
+msgstr ""
+
+#: Console/Command/AclShell.php:141
+msgid "There was a problem creating a new %s '%s'."
+msgstr ""
+
+#: Console/Command/AclShell.php:161;165
+msgid "Node Not Deleted. "
+msgstr ""
+
+#: Console/Command/AclShell.php:161
+msgid "There was an error deleting the %s."
+msgstr ""
+
+#: Console/Command/AclShell.php:163
+msgid "<success>%s deleted.</success>"
+msgstr ""
+
+#: Console/Command/AclShell.php:165
+msgid "There was an error deleting the %s. Node does not exist."
+msgstr ""
+
+#: Console/Command/AclShell.php:187
+msgid "Error in setting new parent. Please make sure the parent node exists, and is not a descendant of the node specified."
+msgstr ""
+
+#: Console/Command/AclShell.php:189
+msgid "Node parent set to %s"
+msgstr ""
+
+#: Console/Command/AclShell.php:207
+msgid "Supplied Node '%s' not found"
+msgstr ""
+
+#: Console/Command/AclShell.php:208;324;326;534
+msgid "No tree returned."
+msgstr ""
+
+#: Console/Command/AclShell.php:211
+msgid "Path:"
+msgstr ""
+
+#: Console/Command/AclShell.php:245
+msgid "%s is <success>allowed</success>."
+msgstr ""
+
+#: Console/Command/AclShell.php:247
+msgid "%s is <error>not allowed</error>."
+msgstr ""
+
+#: Console/Command/AclShell.php:260
+msgid "Permission <success>granted</success>."
+msgstr ""
+
+#: Console/Command/AclShell.php:262
+msgid "Permission was <error>not granted</error>."
+msgstr ""
+
+#: Console/Command/AclShell.php:275
+msgid "Permission denied."
+msgstr ""
+
+#: Console/Command/AclShell.php:277
+msgid "Permission was not denied."
+msgstr ""
+
+#: Console/Command/AclShell.php:290
+msgid "Permission inherited."
+msgstr ""
+
+#: Console/Command/AclShell.php:292
+msgid "Permission was not inherited."
+msgstr ""
+
+#: Console/Command/AclShell.php:324;326;534
+#: Console/Command/ApiShell.php:92
+#: Console/Command/Task/DbConfigTask.php:254
+msgid "%s not found"
+msgstr ""
+
+#: Console/Command/AclShell.php:376
+msgid "Type of node to create."
+msgstr ""
+
+#: Console/Command/AclShell.php:380
+msgid "A console tool for managing the DbAcl"
+msgstr ""
+
+#: Console/Command/AclShell.php:382
+msgid "Create a new ACL node"
+msgstr ""
+
+#: Console/Command/AclShell.php:384
+msgid "Creates a new ACL object <node> under the parent"
+msgstr ""
+
+#: Console/Command/AclShell.php:385
+msgid "You can use `root` as the parent when creating nodes to create top level nodes."
+msgstr ""
+
+#: Console/Command/AclShell.php:389
+msgid "The node selector for the parent."
+msgstr ""
+
+#: Console/Command/AclShell.php:393
+msgid "The alias to use for the newly created node."
+msgstr ""
+
+#: Console/Command/AclShell.php:399
+msgid "Deletes the ACL object with the given <node> reference"
+msgstr ""
+
+#: Console/Command/AclShell.php:401
+msgid "Delete an ACL node."
+msgstr ""
+
+#: Console/Command/AclShell.php:405
+msgid "The node identifier to delete."
+msgstr ""
+
+#: Console/Command/AclShell.php:411
+msgid "Moves the ACL node under a new parent."
+msgstr ""
+
+#: Console/Command/AclShell.php:413
+msgid "Moves the ACL object specified by <node> beneath <parent>"
+msgstr ""
+
+#: Console/Command/AclShell.php:417
+msgid "The node to move"
+msgstr ""
+
+#: Console/Command/AclShell.php:421
+msgid "The new parent for <node>."
+msgstr ""
+
+#: Console/Command/AclShell.php:427
+msgid "Print out the path to an ACL node."
+msgstr ""
+
+#: Console/Command/AclShell.php:430
+msgid "Returns the path to the ACL object specified by <node>."
+msgstr ""
+
+#: Console/Command/AclShell.php:431
+msgid "This command is useful in determining the inheritance of permissions for a certain object in the tree."
+msgstr ""
+
+#: Console/Command/AclShell.php:436
+msgid "The node to get the path of"
+msgstr ""
+
+#: Console/Command/AclShell.php:442
+msgid "Check the permissions between an ACO and ARO."
+msgstr ""
+
+#: Console/Command/AclShell.php:445
+msgid "Use this command to check ACL permissions."
+msgstr ""
+
+#: Console/Command/AclShell.php:448
+msgid "ARO to check."
+msgstr ""
+
+#: Console/Command/AclShell.php:449
+msgid "ACO to check."
+msgstr ""
+
+#: Console/Command/AclShell.php:450
+msgid "Action to check"
+msgstr ""
+
+#: Console/Command/AclShell.php:454
+msgid "Grant an ARO permissions to an ACO."
+msgstr ""
+
+#: Console/Command/AclShell.php:457
+msgid "Use this command to grant ACL permissions. Once executed, the ARO specified (and its children, if any) will have ALLOW access to the specified ACO action (and the ACO's children, if any)."
+msgstr ""
+
+#: Console/Command/AclShell.php:460
+msgid "ARO to grant permission to."
+msgstr ""
+
+#: Console/Command/AclShell.php:461
+msgid "ACO to grant access to."
+msgstr ""
+
+#: Console/Command/AclShell.php:462
+msgid "Action to grant"
+msgstr ""
+
+#: Console/Command/AclShell.php:466
+msgid "Deny an ARO permissions to an ACO."
+msgstr ""
+
+#: Console/Command/AclShell.php:469
+msgid "Use this command to deny ACL permissions. Once executed, the ARO specified (and its children, if any) will have DENY access to the specified ACO action (and the ACO's children, if any)."
+msgstr ""
+
+#: Console/Command/AclShell.php:472
+msgid "ARO to deny."
+msgstr ""
+
+#: Console/Command/AclShell.php:473
+msgid "ACO to deny."
+msgstr ""
+
+#: Console/Command/AclShell.php:474
+msgid "Action to deny"
+msgstr ""
+
+#: Console/Command/AclShell.php:478
+msgid "Inherit an ARO's parent permissions."
+msgstr ""
+
+#: Console/Command/AclShell.php:481
+msgid "Use this command to force a child ARO object to inherit its permissions settings from its parent."
+msgstr ""
+
+#: Console/Command/AclShell.php:484
+msgid "ARO to have permissions inherit."
+msgstr ""
+
+#: Console/Command/AclShell.php:485
+msgid "ACO to inherit permissions on."
+msgstr ""
+
+#: Console/Command/AclShell.php:486
+msgid "Action to inherit"
+msgstr ""
+
+#: Console/Command/AclShell.php:490
+msgid "View a tree or a single node's subtree."
+msgstr ""
+
+#: Console/Command/AclShell.php:493
+msgid "The view command will return the ARO or ACO tree."
+msgstr ""
+
+#: Console/Command/AclShell.php:494
+msgid "The optional node parameter allows you to return"
+msgstr ""
+
+#: Console/Command/AclShell.php:495
+msgid "only a portion of the requested tree."
+msgstr ""
+
+#: Console/Command/AclShell.php:499
+msgid "The optional node to view the subtree of."
+msgstr ""
+
+#: Console/Command/AclShell.php:503
+msgid "Initialize the DbAcl tables. Uses this command : cake schema create DbAcl"
+msgstr ""
+
+#: Console/Command/AclShell.php:570
+msgid "Could not find node using reference \"%s\""
+msgstr ""
+
+#: Console/Command/ApiShell.php:100
+msgid "%s::%s() could not be found"
+msgstr ""
+
+#: Console/Command/ApiShell.php:117
+msgid "Select a number to see the more information about a specific method. q to quit. l to list."
+msgstr ""
+
+#: Console/Command/ApiShell.php:119
+msgid "Done"
+msgstr ""
+
+#: Console/Command/ApiShell.php:148
+msgid "Lookup doc block comments for classes in CakePHP."
+msgstr ""
+
+#: Console/Command/ApiShell.php:150
+msgid "Either a full path or type of class (model, behavior, controller, component, view, helper)"
+msgstr ""
+
+#: Console/Command/ApiShell.php:152
+msgid "A CakePHP core class name (e.g: Component, HtmlHelper)."
+msgstr ""
+
+#: Console/Command/ApiShell.php:155
+msgid "The specific method you want help on."
+msgstr ""
+
+#: Console/Command/ApiShell.php:194
+msgid "Command %s not found"
+msgstr ""
+
+#: Console/Command/ApiShell.php:211
+msgid "%s could not be found"
+msgstr ""
+
+#: Console/Command/BakeShell.php:92
+msgid "Interactive Bake Shell"
+msgstr ""
+
+#: Console/Command/BakeShell.php:94
+msgid "[D]atabase Configuration"
+msgstr ""
+
+#: Console/Command/BakeShell.php:95
+msgid "[M]odel"
+msgstr ""
+
+#: Console/Command/BakeShell.php:96
+msgid "[V]iew"
+msgstr ""
+
+#: Console/Command/BakeShell.php:97
+msgid "[C]ontroller"
+msgstr ""
+
+#: Console/Command/BakeShell.php:98
+msgid "[P]roject"
+msgstr ""
+
+#: Console/Command/BakeShell.php:99
+msgid "[F]ixture"
+msgstr ""
+
+#: Console/Command/BakeShell.php:100
+msgid "[T]est case"
+msgstr ""
+
+#: Console/Command/BakeShell.php:101
+#: Console/Command/I18nShell.php:71
+msgid "[Q]uit"
+msgstr ""
+
+#: Console/Command/BakeShell.php:103
+msgid "What would you like to Bake?"
+msgstr ""
+
+#: Console/Command/BakeShell.php:129
+msgid "You have made an invalid selection. Please choose a type of class to Bake by entering D, M, V, F, T, or C."
+msgstr ""
+
+#: Console/Command/BakeShell.php:197
+msgid "<success>Bake All complete</success>"
+msgstr ""
+
+#: Console/Command/BakeShell.php:200
+msgid "Bake All could not continue without a valid model"
+msgstr ""
+
+#: Console/Command/BakeShell.php:214
+msgid "The Bake script generates controllers, views and models for your application. If run with no command line arguments, Bake guides the user through the class creation process. You can customize the generation process by telling Bake where different parts of your application are using command line arguments."
+msgstr ""
+
+#: Console/Command/BakeShell.php:218
+msgid "Bake a complete MVC. optional <name> of a Model"
+msgstr ""
+
+#: Console/Command/BakeShell.php:220
+msgid "Bake a new app folder in the path supplied or in current directory if no path is specified"
+msgstr ""
+
+#: Console/Command/BakeShell.php:223
+msgid "Bake a new plugin folder in the path supplied or in current directory if no path is specified."
+msgstr ""
+
+#: Console/Command/BakeShell.php:226
+msgid "Bake a database.php file in config directory."
+msgstr ""
+
+#: Console/Command/BakeShell.php:229
+msgid "Bake a model."
+msgstr ""
+
+#: Console/Command/BakeShell.php:232
+msgid "Bake views for controllers."
+msgstr ""
+
+#: Console/Command/BakeShell.php:235
+msgid "Bake a controller."
+msgstr ""
+
+#: Console/Command/BakeShell.php:238
+msgid "Bake a fixture."
+msgstr ""
+
+#: Console/Command/BakeShell.php:241
+msgid "Bake a unit test."
+msgstr ""
+
+#: Console/Command/BakeShell.php:244
+msgid "Database connection to use in conjunction with `bake all`."
+msgstr ""
+
+#: Console/Command/BakeShell.php:249
+#: Console/Command/Task/ControllerTask.php:495
+#: Console/Command/Task/FixtureTask.php:91
+#: Console/Command/Task/ModelTask.php:1020
+#: Console/Command/Task/ProjectTask.php:443
+#: Console/Command/Task/TestTask.php:568
+#: Console/Command/Task/ViewTask.php:438
+msgid "Theme to use when baking code."
+msgstr ""
+
+#: Console/Command/CommandListShell.php:52
+msgid "<info>Current Paths:</info>"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:58
+msgid "<info>Changing Paths:</info>"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:59
+msgid "Your working path should be the same as your application path. To change your path use the '-app' param."
+msgstr ""
+
+#: Console/Command/CommandListShell.php:60
+msgid "Example: %s or %s"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:62
+msgid "<info>Available Shells:</info>"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:90
+msgid "To run an app or core command, type <info>cake shell_name [args]</info>"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:91
+msgid "To run a plugin command, type <info>cake Plugin.shell_name [args]</info>"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:92
+msgid "To get help on a specific command, type <info>cake shell_name --help</info>"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:131
+msgid "Get the list of available shells for this CakePHP application."
+msgstr ""
+
+#: Console/Command/CommandListShell.php:133
+msgid "Does nothing (deprecated)"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:136
+msgid "Get the listing as XML."
+msgstr ""
+
+#: Console/Command/CompletionShell.php:107
+msgid "Used by shells like bash to autocomplete command name, options and arguments"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:109
+msgid "Output a list of available commands"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:111
+msgid "List all availables"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:116
+msgid "Output a list of available subcommands"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:118
+msgid "List subcommands for a command"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:121;132
+msgid "The command name"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:127
+msgid "Output a list of available options"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:129
+msgid "List options"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:138
+msgid "This command is not intended to be called manually"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:91;249
+msgid "Model classes:"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:99
+msgid "There was an error loading the routes config. Please check that the file exists and contains no errors."
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:211
+msgid "Invalid command"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:276
+msgid "Created %s association between %s and %s"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:279
+msgid "Please verify you are using valid models and association types"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:313
+msgid "Removed %s association between %s and %s"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:316
+msgid "Please verify you are using valid models, valid current association, and valid association types"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:375
+msgid "No result set found"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:378
+msgid "%s is not a valid model"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:402
+msgid "Saved record for %s"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:430
+msgid "Please verify that you selected a valid model"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:441
+msgid "There was an error loading the routes config. Please check that the file exists and is free of parse errors."
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:443
+msgid "Routes configuration reloaded, %d routes connected"
+msgstr ""
+
+#: Console/Command/I18nShell.php:66
+msgid "<info>I18n Shell</info>"
+msgstr ""
+
+#: Console/Command/I18nShell.php:68
+msgid "[E]xtract POT file from sources"
+msgstr ""
+
+#: Console/Command/I18nShell.php:69
+msgid "[I]nitialize i18n database table"
+msgstr ""
+
+#: Console/Command/I18nShell.php:70
+msgid "[H]elp"
+msgstr ""
+
+#: Console/Command/I18nShell.php:73
+msgid "What would you like to do?"
+msgstr ""
+
+#: Console/Command/I18nShell.php:87
+msgid "You have made an invalid selection. Please choose a command to execute by entering E, I, H, or Q."
+msgstr ""
+
+#: Console/Command/I18nShell.php:111
+msgid "I18n Shell initializes i18n database table for your application and generates .pot files(s) with translations."
+msgstr ""
+
+#: Console/Command/I18nShell.php:113
+msgid "Initialize the i18n table."
+msgstr ""
+
+#: Console/Command/I18nShell.php:115
+msgid "Extract the po translations from your application"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:109
+msgid "Schema file (%s) could not be found."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:120
+msgid "Generating Schema..."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:135
+msgid "Schema file exists.\n [O]verwrite\n [S]napshot\n [Q]uit\nWould you like to do?"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:189;192
+msgid "Schema file: %s generated"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:209
+msgid "Schema could not be loaded"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:233
+msgid "SQL dump file created in %s"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:236
+msgid "SQL dump could not be created"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:279
+msgid "Performing a dry run."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:295
+msgid "<error>Error</error>: The chosen schema could not be loaded. Attempted to load:"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:296
+msgid "- file: %s"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:297
+msgid "- name: %s"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:330;394
+msgid "Schema is up to date."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:334
+msgid "The following table(s) will be dropped."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:338
+msgid "Are you sure you want to drop the table(s)?"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:340
+msgid "Dropping table(s)."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:344
+msgid "The following table(s) will be created."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:348
+msgid "Are you sure you want to create the table(s)?"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:350
+msgid "Creating table(s)."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:353
+msgid "End create."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:367
+msgid "Comparing Database to Schema..."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:398
+msgid "The following statements will run."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:401
+msgid "Are you sure you want to alter the tables?"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:404
+msgid "Updating Database..."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:408
+msgid "End update."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:421
+msgid "Sql could not be run"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:429
+msgid "%s is up to date."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:432
+msgid "Dry run for %s :"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:450
+msgid "%s updated."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:467
+msgid "The plugin to use."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:471
+msgid "Set the db config to use."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:475
+msgid "Path to read and write schema.php"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:479
+msgid "File name to read and write."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:482
+msgid "Classname to use. If its Plugin.class, both name and plugin options will be set."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:488
+msgid "Snapshot number to use/make."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:492
+msgid "Specify models as comma separated list."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:495
+msgid "Perform a dry run on create and update commands. Queries will be output instead of run."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:502
+msgid "Force \"generate\" to create a new schema"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:506
+msgid "Write the dumped SQL to a file."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:509
+msgid "Tables to exclude as comma separated list."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:513
+msgid "Do not prompt for confirmation. Be careful!"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:518
+msgid "The Schema Shell generates a schema object from the database and updates the database from the schema."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:520
+msgid "Read and output the contents of a schema file"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:526
+msgid "Reads from --connection and writes to --path. Generate snapshots with -s"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:530
+msgid "Generate a snapshot."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:534
+msgid "Dump database SQL based on a schema file to stdout."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:540
+msgid "Drop and create tables based on the schema file."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:545;558
+msgid "Name of schema to use."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:548;561
+msgid "Only create the specified table."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:553
+msgid "Alter the tables based on the schema file."
+msgstr ""
+
+#: Console/Command/ServerShell.php:116
+msgid "DocumentRoot: %s"
+msgstr ""
+
+#: Console/Command/ServerShell.php:127
+msgid "<warning>This command is available on %s or above</warning>"
+msgstr ""
+
+#: Console/Command/ServerShell.php:139
+msgid "built-in server is running in http://%s%s/"
+msgstr ""
+
+#: Console/Command/ServerShell.php:152
+msgid "PHP Built-in Server for CakePHP"
+msgstr ""
+
+#: Console/Command/ServerShell.php:153
+msgid "<warning>[WARN] Don't use this at the production environment</warning>"
+msgstr ""
+
+#: Console/Command/ServerShell.php:156
+msgid "ServerHost"
+msgstr ""
+
+#: Console/Command/ServerShell.php:159
+msgid "ListenPort"
+msgstr ""
+
+#: Console/Command/ServerShell.php:162
+msgid "DocumentRoot"
+msgstr ""
+
+#: Console/Command/TestShell.php:49
+#: Console/Command/TestsuiteShell.php:43
+msgid "The CakePHP Testsuite allows you to run test cases from the command line"
+msgstr ""
+
+#: Console/Command/TestShell.php:51
+msgid "The category for the test, or test file, to test."
+msgstr ""
+
+#: Console/Command/TestShell.php:54
+msgid "The path to the file, or test file, to test."
+msgstr ""
+
+#: Console/Command/TestShell.php:57
+msgid "<file> Log test execution in JUnit XML format to file."
+msgstr ""
+
+#: Console/Command/TestShell.php:60
+msgid "<file> Log test execution in JSON format to file."
+msgstr ""
+
+#: Console/Command/TestShell.php:63
+msgid "<file> Log test execution in TAP format to file."
+msgstr ""
+
+#: Console/Command/TestShell.php:66
+msgid "Log test execution to DBUS."
+msgstr ""
+
+#: Console/Command/TestShell.php:69
+msgid "<dir> Generate code coverage report in HTML format."
+msgstr ""
+
+#: Console/Command/TestShell.php:72
+msgid "<file> Write code coverage data in Clover XML format."
+msgstr ""
+
+#: Console/Command/TestShell.php:75
+msgid "<file> Write agile documentation in HTML format to file."
+msgstr ""
+
+#: Console/Command/TestShell.php:78
+msgid "<file> Write agile documentation in Text format to file."
+msgstr ""
+
+#: Console/Command/TestShell.php:81
+msgid "<pattern> Filter which tests to run."
+msgstr ""
+
+#: Console/Command/TestShell.php:84
+msgid "<name> Only runs tests from the specified group(s)."
+msgstr ""
+
+#: Console/Command/TestShell.php:87
+msgid "<name> Exclude tests from the specified group(s)."
+msgstr ""
+
+#: Console/Command/TestShell.php:90
+msgid "List available test groups."
+msgstr ""
+
+#: Console/Command/TestShell.php:93
+msgid "TestSuiteLoader implementation to use."
+msgstr ""
+
+#: Console/Command/TestShell.php:96
+msgid "<times> Runs the test(s) repeatedly."
+msgstr ""
+
+#: Console/Command/TestShell.php:99
+msgid "Report test execution progress in TAP format."
+msgstr ""
+
+#: Console/Command/TestShell.php:102
+msgid "Report test execution progress in TestDox format."
+msgstr ""
+
+#: Console/Command/TestShell.php:106
+msgid "Do not use colors in output."
+msgstr ""
+
+#: Console/Command/TestShell.php:109
+msgid "Write to STDERR instead of STDOUT."
+msgstr ""
+
+#: Console/Command/TestShell.php:112
+msgid "Stop execution upon first error or failure."
+msgstr ""
+
+#: Console/Command/TestShell.php:115
+msgid "Stop execution upon first failure."
+msgstr ""
+
+#: Console/Command/TestShell.php:118
+msgid "Stop execution upon first skipped test."
+msgstr ""
+
+#: Console/Command/TestShell.php:121
+msgid "Stop execution upon first incomplete test."
+msgstr ""
+
+#: Console/Command/TestShell.php:124
+msgid "Mark a test as incomplete if no assertions are made."
+msgstr ""
+
+#: Console/Command/TestShell.php:127
+msgid "Waits for a keystroke after each test."
+msgstr ""
+
+#: Console/Command/TestShell.php:130
+msgid "Run each test in a separate PHP process."
+msgstr ""
+
+#: Console/Command/TestShell.php:133
+msgid "Do not backup and restore $GLOBALS for each test."
+msgstr ""
+
+#: Console/Command/TestShell.php:136
+msgid "Backup and restore static attributes for each test."
+msgstr ""
+
+#: Console/Command/TestShell.php:139
+msgid "Try to check source files for syntax errors."
+msgstr ""
+
+#: Console/Command/TestShell.php:142
+msgid "<file> A \"bootstrap\" PHP file that is run before the tests."
+msgstr ""
+
+#: Console/Command/TestShell.php:145
+msgid "<file> Read configuration from XML file."
+msgstr ""
+
+#: Console/Command/TestShell.php:148
+msgid "Ignore default configuration file (phpunit.xml)."
+msgstr ""
+
+#: Console/Command/TestShell.php:151
+msgid "<path(s)> Prepend PHP include_path with given path(s)."
+msgstr ""
+
+#: Console/Command/TestShell.php:154
+msgid "key[=value] Sets a php.ini value."
+msgstr ""
+
+#: Console/Command/TestShell.php:157
+msgid "Choose a custom fixture manager."
+msgstr ""
+
+#: Console/Command/TestShell.php:159
+msgid "More verbose output."
+msgstr ""
+
+#: Console/Command/TestShell.php:250
+#: Console/Command/TestsuiteShell.php:88
+msgid "CakePHP Test Shell"
+msgstr ""
+
+#: Console/Command/TestShell.php:299
+msgid "No test cases available \n\n"
+msgstr ""
+
+#: Console/Command/TestShell.php:313
+msgid "What test case would you like to run?"
+msgstr ""
+
+#: Console/Command/TestsuiteShell.php:44
+msgid "<warning>This shell is for backwards-compatibility only</warning>\nuse the test shell instead"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:73
+msgid "<warning>Dry-run mode enabled!</warning>"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:76
+msgid "<warning>No git repository detected!</warning>"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:91
+msgid "Running %s"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:140
+msgid "Upgrading locations for plugin %s"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:145
+msgid "Upgrading locations for app directory"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:162;618;645;737
+msgid "Moving %s to %s"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:760
+msgid "Updating %s..."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:801
+msgid " * Updating %s"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:805
+msgid "Done updating %s"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:823
+msgid "The plugin to update. Only the specified plugin will be updated."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:827
+msgid "The extension(s) to search. A pipe delimited list, or a preg_match compatible subpattern"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:832
+msgid "Use git command for moving files around."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:837
+msgid "Dry run the update, no files will actually be modified."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:844
+msgid "A tool to help automate upgrading an application or plugin from CakePHP 1.3 to 2.0. Be sure to have a backup of your application before running these commands."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:848
+msgid "Run all upgrade commands."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:851
+msgid "Update tests class names to FooTest rather than FooTestCase."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:854
+msgid "Move files and folders to their new homes."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:857
+msgid "Update the i18n translation method calls."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:860
+msgid "Update calls to helpers."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:863
+msgid "Update removed basics functions to PHP native functions."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:866
+msgid "Update removed request access, and replace with $this->request."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:869
+msgid "Update Configure::read() to Configure::read('debug')"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:872
+msgid "Replace Obsolete constants"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:875
+msgid "Return early on controller redirect calls."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:878
+msgid "Update components to extend Component class."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:881
+msgid "Replace use of cakeError with exceptions."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:75
+msgid "Baking basic crud methods for "
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:81;121
+msgid "Adding %s methods"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:132
+msgid "No Controllers were baked, Models need to exist before Controllers can be baked."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:144
+msgid "Bake Controller\nPath: %s"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:153
+msgid "Baking %sController"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:163
+msgid "Would you like to build your controller interactively?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:165
+msgid "Warning: Choosing no will overwrite the %sController."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:172
+msgid "Would you like to use dynamic scaffolding?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:185
+msgid "Would you like to use Session flash messages?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:208
+#: Console/Command/Task/DbConfigTask.php:238
+#: Console/Command/Task/ModelTask.php:274
+#: Console/Command/Task/PluginTask.php:105
+#: Console/Command/Task/ProjectTask.php:196
+#: Console/Command/Task/ViewTask.php:332
+msgid "Look okay?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:237
+msgid "The following controller will be created:"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:239
+msgid "Controller Name:\n\t%s"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:246
+msgid "Helpers:"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:247
+msgid "Components:"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:274
+msgid "Would you like to create some basic class methods \n(index(), add(), view(), edit())?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:278
+msgid "Would you like to create the basic class methods for admin routing?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:300
+msgid "You must have a model for this class to build basic methods. Please try again."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:332
+msgid "Baking controller class for %s..."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:376
+msgid "Would you like this controller to use other helpers\nbesides HtmlHelper and FormHelper?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:377
+msgid "Please provide a comma separated list of the other\nhelper names you'd like to use.\nExample: 'Text, Js, Time'"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:389
+msgid "Would you like this controller to use other components\nbesides PaginatorComponent?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:390
+msgid "Please provide a comma separated list of the component names you'd like to use.\nExample: 'Acl, Security, RequestHandler'"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:425
+msgid "Possible Controllers based on your current database:"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:449
+msgid "Enter a number from the list above,\ntype in the name of another controller, or 'q' to exit"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:451
+#: Console/Command/Task/ModelTask.php:984
+msgid "Exit"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:456
+msgid "The Controller name you supplied was empty,\nor the number you selected was not an option. Please try again."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:478
+msgid "Bake a controller for a model. Using options you can bake public, admin or both."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:480
+msgid "Name of the controller to bake. Can use Plugin.name to bake controllers into plugins."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:482
+msgid "Bake a controller with basic crud actions (index, view, add, edit, delete)."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:485
+msgid "Bake a controller with crud actions for one of the Routing.prefixes."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:489
+msgid "Plugin to bake the controller into."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:492
+msgid "The connection the controller's model is on."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:498
+#: Console/Command/Task/FixtureTask.php:94
+#: Console/Command/Task/ModelTask.php:1026
+#: Console/Command/Task/TestTask.php:574
+#: Console/Command/Task/ViewTask.php:444
+msgid "Force overwriting existing files without prompting."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:500
+msgid "Bake all controllers with CRUD methods."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:502
+#: Console/Command/Task/FixtureTask.php:101
+#: Console/Command/Task/ModelTask.php:1028
+#: Console/Command/Task/TestTask.php:576
+#: Console/Command/Task/ViewTask.php:448
+msgid "Omitting all arguments and options will enter into an interactive mode."
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:89
+msgid "Database Configuration:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:98
+msgid "Name:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:101
+msgid "The name may only contain unaccented latin characters, numbers or underscores"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:104
+msgid "The name must start with an unaccented latin character or an underscore"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:108
+msgid "Datasource:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:110
+msgid "Persistent Connection?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:119
+msgid "Database Host:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:124
+msgid "Port?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:133
+msgid "User:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:139
+msgid "Password:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:142
+msgid "The password you supplied was empty. Use an empty password?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:151
+msgid "Database Name:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:156
+msgid "Table Prefix?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:164
+msgid "Table encoding?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:173
+msgid "Table schema?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:187
+msgid "Do you wish to add another database configuration?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:210
+msgid "The following database configuration will be created:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:212
+msgid "Name:         %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:213
+msgid "Datasource:   %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:214
+msgid "Persistent:   %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:215
+msgid "Host:         %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:218
+msgid "Port:         %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:221
+msgid "User:         %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:222
+msgid "Pass:         %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:223
+msgid "Database:     %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:226
+msgid "Table prefix: %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:230
+msgid "Schema:       %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:234
+msgid "Encoding:     %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:365
+msgid "Use Database Config"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:379
+msgid "Bake new database configuration settings."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:123
+msgid "Current paths: %s\nWhat is the path you would like to extract?\n[Q]uit [D]one"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:130;207
+msgid "Extract Aborted"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:136
+msgid "<warning>No directories selected.</warning> Please choose a directory."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:141;213
+msgid "The directory path you supplied was not found. Please try again."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:175
+msgid "Would you like to extract the messages from the CakePHP core?"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:203
+msgid "What is the path you would like to output?\n[Q]uit"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:223
+msgid "Would you like to merge all domain and category strings into the default.pot file?"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:233
+msgid "The output directory %s was not found or writable."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:283
+msgid "Extracting..."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:285
+msgid "Paths:"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:289
+msgid "Output Directory: "
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:299
+msgid "Done."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:311
+msgid "CakePHP Language String Extraction:"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:313
+msgid "Directory where your application is located."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:315
+msgid "Comma separated list of paths."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:317
+msgid "Merge all domain and category strings into the default.po file."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:320
+msgid "Full path to output directory."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:322
+msgid "Comma separated list of files."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:326
+msgid "Ignores all files in plugins if this command is run inside from the same app directory."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:328
+msgid "Extracts tokens only from the plugin specified and puts the result in the plugin's Locale directory."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:332
+msgid "Ignores validation messages in the $validate property. If this flag is not set and the command is run from the same app directory, all messages in model validation rules will be extracted as tokens."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:337
+msgid "If set to a value, the localization domain to be used for model validation messages."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:339
+msgid "Comma separated list of directories to exclude. Any path containing a path segment with the provided values will be skipped. E.g. test,vendors"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:345
+msgid "Always overwrite existing .pot files."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:347
+msgid "Extract messages from the CakePHP core libs."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:362
+msgid "Processing %s..."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:655
+msgid "Error: %s already exists in this location. Overwrite? [Y]es, [N]o, [A]ll"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:662
+msgid "What would you like to name this file?"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:759
+msgid "Invalid marker content in %s:%s\n* %s("
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:71
+msgid "Generate fixtures for use with the test suite. You can use `bake fixture all` to bake all fixtures."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:73
+msgid "Name of the fixture to bake. Can use Plugin.name to bake plugin fixtures."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:75
+msgid "When using generated data, the number of records to include in the fixture(s)."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:79
+msgid "Which database configuration to use for baking."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:83
+msgid "CamelCased name of the plugin to bake fixtures for."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:86
+msgid "Importing schema for fixtures rather than hardcoding it."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:96
+msgid "Used with --count and <name>/all commands to pull [n] records from the live tables, where [n] is either --count or the default of 10."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:160
+msgid "Bake Fixture\nPath: %s"
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:184
+msgid "Would you like to import schema for this fixture?"
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:192
+msgid "Would you like to use record importing for this fixture?"
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:198
+msgid "Would you like to build this fixture with data from %s's table?"
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:286
+msgid "Baking test fixture for %s..."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:419
+msgid "Please provide a SQL fragment to use as conditions\nExample: WHERE 1=1"
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:423
+msgid "How many records do you want to import?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:128
+msgid "Baking %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:176
+msgid "Make a selection from the choices above"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:193
+msgid "Bake Model\nPath: %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:208
+msgid "The table %s doesn't exist or could not be automatically detected\ncontinue anyway?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:234
+msgid "Would you like to supply validation criteria \nfor the fields in your model?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:240
+msgid "Would you like to define model associations\n(hasMany, hasOne, belongsTo, etc.)?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:249
+msgid "The following Model will be created:"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:251
+msgid "Name:       %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:254
+msgid "DB Config:  %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:257
+msgid "DB Table:   %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:260
+msgid "Primary Key: %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:263
+msgid "Validation: %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:266
+msgid "Associations:"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:320
+msgid "What is the primaryKey?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:331
+msgid "A displayField could not be automatically detected\nwould you like to choose one?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:336
+msgid "Choose a field from the options above:"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:411
+msgid "or enter in a valid regex validation string.\nAlternatively [s] skip the rest of the fields.\n"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:420
+msgid "Field: <info>%s</info>"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:421
+msgid "Type: <info>%s</info>"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:423
+msgid "Please select one of the following validation options:"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:435
+msgid "%s - Do not do any validation on this field."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:473
+msgid "You have already chosen that validation rule,\nplease choose again"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:477
+msgid "Please make a valid selection."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:499
+msgid "Would you like to add another validation rule\nor skip the rest of the fields?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:521
+msgid "One moment while the associations are detected."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:551
+msgid "None found."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:553
+msgid "Please confirm the following associations:"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:725
+msgid "Would you like to define some additional model associations?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:730
+msgid "What is the association type?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:731
+msgid "Enter a number"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:733
+msgid "For the following options be very careful to match your setup exactly.\nAny spelling mistakes will cause errors."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:737
+msgid "What is the alias for this association?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:738
+msgid "What className will %s use?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:760
+msgid "What is the table for this model?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:766
+msgid "A helpful List of possible keys"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:767
+msgid "What is the foreignKey?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:771
+msgid "What is the foreignKey? Specify your own."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:774
+msgid "What is the associationForeignKey?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:775
+msgid "What is the joinTable?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:787
+msgid "Define another association?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:859
+msgid "Baking model class for %s..."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:893
+msgid "Possible Models based on your current database:"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:925
+msgid "Given your model named '%s',\nCake would expect a database table named '%s'"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:926
+msgid "Do you want to use this table?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:929
+msgid "What is the name of the table (without prefix)?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:961
+msgid "Your database does not have any tables."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:980
+msgid "Enter a number from the list above,\ntype in the name of another model, or 'q' to exit"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:989
+msgid "The model name you supplied was empty,\nor the number you selected was not an option. Please try again."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:1010
+msgid "Bake models."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:1012
+msgid "Name of the model to bake. Can use Plugin.name to bake plugin models."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:1014
+msgid "Bake all model files with associations and validation."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:1017
+msgid "Plugin to bake the model into."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:1023
+msgid "The connection the model table is on."
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:63
+msgid "Plugin: %s already exists, no action taken"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:81
+msgid "Enter the name of the plugin in CamelCase format"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:85
+msgid "An error occurred trying to bake: %s in %s"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:101
+msgid "<info>Plugin Name:</info> %s"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:102
+msgid "<info>Plugin Directory:</info> %s"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:169
+#: Console/Command/Task/ProjectTask.php:207
+msgid "<success>Created:</success> %s in %s"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:211
+msgid "Choose a plugin path from the paths above."
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:229
+msgid "Create the directory structure, AppModel and AppController classes for a new plugin. Can create plugins in any of your bootstrapped plugin paths."
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:232
+msgid "CamelCased name of the plugin to create."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:58
+msgid "What is the path to the project you want to bake?"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:68
+msgid "<warning>A project already exists in this location:</warning> %s Overwrite?"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:80
+msgid " * Random hash key created for 'Security.salt'"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:82
+msgid "Unable to generate random hash for 'Security.salt', you should change it in %s"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:87
+msgid " * Random seed created for 'Security.cipherSeed'"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:89
+msgid "Unable to generate random seed for 'Security.cipherSeed', you should change it in %s"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:94
+msgid " * Cache prefix set"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:96
+msgid "The cache prefix was <error>NOT</error> set"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:101
+msgid " * app/Console/cake.php path set."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:103
+msgid "Unable to set console path for app/Console."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:109
+msgid "<info>CakePHP is on your `include_path`. CAKE_CORE_INCLUDE_PATH will be set, but commented out.</info>"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:111
+msgid "<warning>CakePHP is not on your `include_path`, CAKE_CORE_INCLUDE_PATH will be hard coded.</warning>"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:112
+msgid "You can fix this by adding CakePHP to your `include_path`."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:117;118
+msgid " * CAKE_CORE_INCLUDE_PATH set to %s in %s"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:120
+msgid "Unable to set CAKE_CORE_INCLUDE_PATH, you should change it in %s"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:124
+msgid "   * <warning>Remember to check these values after moving to production server</warning>"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:129
+msgid "Could not set permissions on %s"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:134
+msgid "<success>Project baked successfully!</success>"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:136
+msgid "Project baked but with <warning>some issues.</warning>."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:173
+msgid "What is the path to the directory layout you wish to copy?"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:178
+msgid "The directory path you supplied was empty. Please try again."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:182
+msgid "Directory path does not exist please choose another:"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:192
+msgid "<info>Skel Directory</info>: "
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:193
+msgid "<info>Will be copied to</info>: "
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:210
+msgid "<error>Could not create</error> '%s' properly."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:224
+msgid "<error>Bake Aborted.</error>"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:392
+msgid "You have more than one routing prefix configured"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:401
+msgid "Please choose a prefix to bake with."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:406;416
+msgid "You need to enable %s in %s to use prefix routing."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:409
+msgid "What would you like the prefix route to be?"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:410
+msgid "Example: %s"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:412
+msgid "Enter a routing prefix:"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:415
+msgid "<error>Unable to write to</error> %s."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:435
+msgid "Generate a new CakePHP project skeleton."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:437
+msgid "Application directory to make, if it starts with \"/\" the path is absolute."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:440
+msgid "Create empty files in each of the directories. Good if you are using git"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:446
+msgid "The directory layout to use for the new application skeleton. Defaults to cake/Console/Templates/skel of CakePHP used to create the project."
+msgstr ""
+
+#: Console/Command/Task/TemplateTask.php:176
+msgid "You have more than one set of templates installed."
+msgstr ""
+
+#: Console/Command/Task/TemplateTask.php:177
+msgid "Please choose the template set you wish to use:"
+msgstr ""
+
+#: Console/Command/Task/TemplateTask.php:187
+msgid "Which bake theme would you like to use?"
+msgstr ""
+
+#: Console/Command/Task/TemplateTask.php:213
+msgid "Could not find template for %s"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:111
+msgid "Bake Tests"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:118
+msgid "Incorrect type provided. Please choose one of %s"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:144
+msgid "Bake is detecting possible fixtures..."
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:162
+msgid "Baking test case for %s %s ..."
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:188
+msgid "Select an object type:"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:198
+msgid "Enter the type of object to bake a test for or (q)uit"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:222
+msgid "Choose a %s class"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:229
+msgid "Choose an existing class, or enter the name of a class that does not exist"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:453
+msgid "Bake could not detect fixtures, would you like to add some?"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:456
+msgid "Please provide a comma separated list of the fixtures names you'd like to use.\nExample: 'app.comment, app.post, plugin.forums.post'"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:554
+msgid "Bake test case skeletons for classes."
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:556
+msgid "Type of class to bake, can be any of the following: controller, model, helper, component or behavior."
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:565
+msgid "An existing class to bake tests for."
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:571
+msgid "CamelCased name of the plugin to bake tests for."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:209
+msgid "Would you like bake to build your views interactively?\nWarning: Choosing no will overwrite %s views if they exist."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:216
+msgid "Would you like to create some CRUD views\n(index, add, view, edit) for this controller?\nNOTE: Before doing so, you'll need to create your controller\nand model classes (including associated models)."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:219
+msgid "Would you like to create the views for admin routing?"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:238
+msgid "View Scaffolding Complete.\n"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:255
+msgid "Controller not found"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:267
+msgid "The file '%s' could not be found.\nIn order to bake a view, you'll need to first create the controller."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:319
+msgid "Action Name? (use lowercase_underscored function name)"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:321
+msgid "The action name you supplied was empty. Please try again."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:326
+msgid "The following view will be created:"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:328
+msgid "Controller Name: %s"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:329
+msgid "Action Name:     %s"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:330
+msgid "Path:            %s"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:337
+msgid "Bake Aborted."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:354
+msgid "Baking `%s` view file..."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:423
+msgid "Bake views for a controller, using built-in or custom templates."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:425
+msgid "Name of the controller views to bake. Can be Plugin.name as a shortcut for plugin baking."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:427
+msgid "Will bake a single action's file. core templates are (index, add, edit, view)"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:429
+msgid "Will bake the template in <action> but create the filename after <alias>."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:432
+msgid "Plugin to bake the view into."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:434
+msgid "Set to only bake views for a prefix in Routing.prefixes"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:441
+msgid "The connection the connected model is on."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:446
+msgid "Bake all CRUD action views for all controllers. Requires models and controllers to exist."
+msgstr ""
+

--- a/Locale/cake_dev.pot
+++ b/Locale/cake_dev.pot
@@ -1,0 +1,1209 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2015-01-19 07:43+0000\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: View/Layouts/default.ctp:17
+#: View/Layouts/error.ctp:17
+msgid "CakePHP: the rapid development php framework"
+msgstr ""
+
+#: View/Layouts/default.ctp:18
+msgid "CakePHP %s"
+msgstr ""
+
+#: View/Pages/home.ctp:14
+msgid "Release Notes for CakePHP %s."
+msgstr ""
+
+#: View/Pages/home.ctp:16
+msgid "Read the changelog"
+msgstr ""
+
+#: View/Pages/home.ctp:25
+msgid "URL rewriting is not properly configured on your server."
+msgstr ""
+
+#: View/Pages/home.ctp:34
+msgid "Your version of PHP is 5.2.8 or higher."
+msgstr ""
+
+#: View/Pages/home.ctp:38
+msgid "Your version of PHP is too low. You need PHP 5.2.8 or higher to use CakePHP."
+msgstr ""
+
+#: View/Pages/home.ctp:47
+msgid "Your tmp directory is writable."
+msgstr ""
+
+#: View/Pages/home.ctp:51
+msgid "Your tmp directory is NOT writable."
+msgstr ""
+
+#: View/Pages/home.ctp:61
+msgid "The %s is being used for core caching. To change the config edit %s"
+msgstr ""
+
+#: View/Pages/home.ctp:65
+msgid "Your cache is NOT working. Please check the settings in %s"
+msgstr ""
+
+#: View/Pages/home.ctp:75
+msgid "Your database configuration file is present."
+msgstr ""
+
+#: View/Pages/home.ctp:80
+msgid "Your database configuration file is NOT present."
+msgstr ""
+
+#: View/Pages/home.ctp:82
+msgid "Rename %s to %s"
+msgstr ""
+
+#: View/Pages/home.ctp:107
+msgid "CakePHP is able to connect to the database."
+msgstr ""
+
+#: View/Pages/home.ctp:111
+msgid "CakePHP is NOT able to connect to the database."
+msgstr ""
+
+#: View/Pages/home.ctp:124
+msgid "PCRE has not been compiled with Unicode support."
+msgstr ""
+
+#: View/Pages/home.ctp:126
+msgid "Recompile PCRE with Unicode support by adding <code>--enable-unicode-properties</code> when configuring"
+msgstr ""
+
+#: View/Pages/home.ctp:135
+msgid "DebugKit plugin is present"
+msgstr ""
+
+#: View/Pages/home.ctp:139
+msgid "DebugKit is not installed. It will help you inspect and debug different aspects of your application."
+msgstr ""
+
+#: View/Pages/home.ctp:141
+msgid "You can install it from %s"
+msgstr ""
+
+#: View/Pages/home.ctp:147
+msgid "Editing this Page"
+msgstr ""
+
+#: View/Pages/home.ctp:150
+msgid "To change the content of this page, edit: %s.<br />\nTo change its layout, edit: %s.<br />\nYou can also add some CSS styles for your pages at: %s."
+msgstr ""
+
+#: View/Pages/home.ctp:157
+msgid "Getting Started"
+msgstr ""
+
+#: View/Pages/home.ctp:161
+msgid "New"
+msgstr ""
+
+#: View/Pages/home.ctp:161
+msgid "CakePHP 2.0 Docs"
+msgstr ""
+
+#: View/Pages/home.ctp:170
+msgid "The 15 min Blog Tutorial"
+msgstr ""
+
+#: View/Pages/home.ctp:177
+msgid "Official Plugins"
+msgstr ""
+
+#: View/Pages/home.ctp:182
+msgid "provides a debugging toolbar and enhanced debugging tools for CakePHP applications."
+msgstr ""
+
+#: View/Pages/home.ctp:186
+msgid "contains various localized validation classes and translations for specific countries"
+msgstr ""
+
+#: View/Pages/home.ctp:191
+msgid "More about CakePHP"
+msgstr ""
+
+#: View/Pages/home.ctp:193
+msgid "CakePHP is a rapid development framework for PHP which uses commonly known design patterns like Active Record, Association Data Mapping, Front Controller and MVC."
+msgstr ""
+
+#: View/Pages/home.ctp:196
+msgid "Our primary goal is to provide a structured framework that enables PHP users at all levels to rapidly develop robust web applications, without any loss to flexibility."
+msgstr ""
+
+#: View/Pages/home.ctp:201
+msgid "The Rapid Development Framework"
+msgstr ""
+
+#: View/Pages/home.ctp:202
+msgid "CakePHP Documentation"
+msgstr ""
+
+#: View/Pages/home.ctp:203
+msgid "Your Rapid Development Cookbook"
+msgstr ""
+
+#: View/Pages/home.ctp:204
+msgid "CakePHP API"
+msgstr ""
+
+#: View/Pages/home.ctp:205
+msgid "Quick API Reference"
+msgstr ""
+
+#: View/Pages/home.ctp:206
+msgid "The Bakery"
+msgstr ""
+
+#: View/Pages/home.ctp:207
+msgid "Everything CakePHP"
+msgstr ""
+
+#: View/Pages/home.ctp:208
+msgid "CakePHP Plugins"
+msgstr ""
+
+#: View/Pages/home.ctp:209
+msgid "A comprehensive list of all CakePHP plugins created by the community"
+msgstr ""
+
+#: View/Pages/home.ctp:210
+msgid "CakePHP Community Center"
+msgstr ""
+
+#: View/Pages/home.ctp:211
+msgid "Everything related to the CakePHP community in one place"
+msgstr ""
+
+#: View/Pages/home.ctp:212
+msgid "CakePHP Google Group"
+msgstr ""
+
+#: View/Pages/home.ctp:213
+msgid "Community mailing list"
+msgstr ""
+
+#: View/Pages/home.ctp:215
+msgid "Live chat about CakePHP"
+msgstr ""
+
+#: View/Pages/home.ctp:216
+msgid "CakePHP Code"
+msgstr ""
+
+#: View/Pages/home.ctp:217
+msgid "Find the CakePHP code on GitHub and contribute to the framework"
+msgstr ""
+
+#: View/Pages/home.ctp:218;219
+msgid "CakePHP Issues"
+msgstr ""
+
+#: View/Pages/home.ctp:220;221
+msgid "CakePHP Roadmaps"
+msgstr ""
+
+#: View/Pages/home.ctp:222
+msgid "Training"
+msgstr ""
+
+#: View/Pages/home.ctp:223
+msgid "Join a live session and get skilled with the framework"
+msgstr ""
+
+#: View/Pages/home.ctp:224
+msgid "CakeFest"
+msgstr ""
+
+#: View/Pages/home.ctp:225
+msgid "Don't miss our annual CakePHP conference"
+msgstr ""
+
+#: View/Pages/home.ctp:226
+msgid "Cake Software Foundation"
+msgstr ""
+
+#: View/Pages/home.ctp:227
+msgid "Promoting development related to CakePHP"
+msgstr ""
+
+#: webroot/test.php:103
+msgid "Debug setting does not allow access to this url."
+msgstr ""
+
+#: Cache/Cache.php:173
+msgid "Cache engine %s is not available."
+msgstr ""
+
+#: Cache/Cache.php:177
+msgid "Cache engines must use %s as a base class."
+msgstr ""
+
+#: Cache/Cache.php:181
+msgid "Cache engine \"%s\" is not properly configured. Ensure required extensions are installed, and credentials/permissions are correct"
+msgstr ""
+
+#: Cache/Cache.php:321
+msgid "%s cache was unable to write '%s' to %s cache"
+msgstr ""
+
+#: Cache/Cache.php:543
+msgid "Invalid cache group %s"
+msgstr ""
+
+#: Cache/Engine/FileEngine.php:313
+msgid "Files cannot be atomically decremented."
+msgstr ""
+
+#: Cache/Engine/FileEngine.php:325
+msgid "Files cannot be atomically incremented."
+msgstr ""
+
+#: Cache/Engine/FileEngine.php:362
+msgid "Could not apply permission mask \"%s\" on cache file \"%s\""
+msgstr ""
+
+#: Cache/Engine/FileEngine.php:385
+msgid "%s is not writable"
+msgstr ""
+
+#: Cache/Engine/MemcacheEngine.php:166;183
+msgid "Method %s not implemented for compressed cache in %s"
+msgstr ""
+
+#: Cache/Engine/MemcachedEngine.php:133
+msgid "Memcached extension is not build with SASL support"
+msgstr ""
+
+#: Cache/Engine/MemcachedEngine.php:160
+msgid "%s is not a valid serializer engine for Memcached"
+msgstr ""
+
+#: Cache/Engine/MemcachedEngine.php:166
+msgid "Memcached extension is not compiled with %s support"
+msgstr ""
+
+#: Configure/IniReader.php:101
+#: Configure/PhpReader.php:64
+msgid "Cannot load configuration files with ../ in them."
+msgstr ""
+
+#: Configure/IniReader.php:106
+#: Configure/PhpReader.php:69
+msgid "Could not load configuration file: %s"
+msgstr ""
+
+#: Configure/PhpReader.php:74
+msgid "No variable %s found in %s"
+msgstr ""
+
+#: Console/Command/TestShell.php:175
+msgid "Please install PHPUnit framework v3.7 <info>(http://www.phpunit.de)</info>"
+msgstr ""
+
+#: Console/Command/TestShell.php:371
+msgid "Test case %s cannot be run via this shell"
+msgstr ""
+
+#: Console/Command/TestShell.php:384;401
+msgid "Test case %s not found"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:187
+msgid "%s modified"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:322
+msgid "Invalid object type."
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:341
+msgid "Invalid type name"
+msgstr ""
+
+#: Controller/Component/AclComponent.php:67
+msgid "Could not find %s."
+msgstr ""
+
+#: Controller/Component/AclComponent.php:91
+msgid "AclComponent adapters must implement AclInterface"
+msgstr ""
+
+#: Controller/Component/AclComponent.php:162;176
+msgid "%s is deprecated, use %s instead"
+msgstr ""
+
+#: Controller/Component/AuthComponent.php:496
+msgid "Authorization adapter \"%s\" was not found."
+msgstr ""
+
+#: Controller/Component/AuthComponent.php:499
+msgid "Authorization objects must implement an %s method."
+msgstr ""
+
+#: Controller/Component/AuthComponent.php:796
+msgid "Authentication adapter \"%s\" was not found."
+msgstr ""
+
+#: Controller/Component/AuthComponent.php:799
+msgid "Authentication objects must implement an %s method."
+msgstr ""
+
+#: Controller/Component/CookieComponent.php:387
+msgid "You must use cipher, rijndael or aes for cookie encryption type"
+msgstr ""
+
+#: Controller/Component/RequestHandlerComponent.php:757
+msgid "You must give a handler callback."
+msgstr ""
+
+#: Controller/Component/SecurityComponent.php:335;620
+msgid "The request has been black-holed"
+msgstr ""
+
+#: Controller/Component/Acl/PhpAcl.php:104
+msgid "\"roles\" section not found in configuration."
+msgstr ""
+
+#: Controller/Component/Acl/PhpAcl.php:108
+msgid "Neither \"allow\" nor \"deny\" rules were provided in configuration."
+msgstr ""
+
+#: Controller/Component/Acl/PhpAcl.php:528
+msgid "cycle detected when inheriting %s from %s. Path: %s"
+msgstr ""
+
+#: Controller/Component/Auth/BaseAuthenticate.php:172
+msgid "Password hasher class \"%s\" was not found."
+msgstr ""
+
+#: Controller/Component/Auth/BaseAuthenticate.php:175
+msgid "Password hasher must extend AbstractPasswordHasher class."
+msgstr ""
+
+#: Controller/Component/Auth/BaseAuthorize.php:95
+msgid "$controller needs to be an instance of Controller"
+msgstr ""
+
+#: Controller/Component/Auth/ControllerAuthorize.php:49
+msgid "$controller does not implement an %s method."
+msgstr ""
+
+#: Controller/Component/Auth/CrudAuthorize.php:83
+msgid "CrudAuthorize::authorize() - Attempted access of un-mapped action \"%1$s\" in controller \"%2$s\""
+msgstr ""
+
+#: Core/Configure.php:73
+msgid "Can't find application core file. Please create %s, and make sure it is readable by PHP."
+msgstr ""
+
+#: Core/Configure.php:93
+msgid "Can't find application bootstrap file. Please create %s, and make sure it is readable by PHP."
+msgstr ""
+
+#: Core/Configure.php:341
+msgid "There is no \"%s\" adapter."
+msgstr ""
+
+#: Core/Configure.php:344
+msgid "The \"%s\" adapter, does not have a %s method."
+msgstr ""
+
+#: Event/CakeEventManager.php:102
+msgid "The eventKey variable is required"
+msgstr ""
+
+#: I18n/I18n.php:229
+msgid "You cannot use \"\" as a domain."
+msgstr ""
+
+#: I18n/I18n.php:269
+msgid "Missing plural form translation for \"%s\" in \"%s\" domain, \"%s\" locale.  Check your po file for correct plurals and valid Plural-Forms header."
+msgstr ""
+
+#: Log/CakeLog.php:191
+msgid "Invalid key name"
+msgstr ""
+
+#: Log/CakeLog.php:194
+msgid "Missing logger class name"
+msgstr ""
+
+#: Log/CakeLog.php:315;333;352
+msgid "Stream %s not found"
+msgstr ""
+
+#: Log/LogEngineCollection.php:44
+msgid "logger class %s does not implement a %s method."
+msgstr ""
+
+#: Log/LogEngineCollection.php:69
+msgid "Could not load class %s"
+msgstr ""
+
+#: Log/Engine/FileLog.php:150
+msgid "Could not apply permission mask \"%s\" on log file \"%s\""
+msgstr ""
+
+#: Model/AclNode.php:178
+msgid "AclNode::node() - Couldn't find %s node identified by \"%s\""
+msgstr ""
+
+#: Model/BehaviorCollection.php:226
+msgid "%s - Method %s not found in any attached behavior"
+msgstr ""
+
+#: Model/CakeSchema.php:613
+msgid "Schema generation error: invalid column type %s for %s.%s does not exist in DBO"
+msgstr ""
+
+#: Model/Model.php:1413
+msgid "(Model::getColumnTypes) Unable to build model field data. If you are using a model without a database table, try implementing schema()"
+msgstr ""
+
+#: Model/Model.php:3725
+msgid "Invalid join model settings in %s. The association parameter has the wrong type, expecting a string or array, but was passed type: %s"
+msgstr ""
+
+#: Model/Permission.php:84
+msgid "%s - Failed ARO node lookup in permissions check. Node references:\nAro: %s\nAco: %s"
+msgstr ""
+
+#: Model/Permission.php:95
+msgid "%s - Failed ACO node lookup in permissions check. Node references:\nAro: %s\nAco: %s"
+msgstr ""
+
+#: Model/Permission.php:106
+msgid "ACO permissions key %s does not exist in %s"
+msgstr ""
+
+#: Model/Permission.php:177
+msgid "%s - Invalid node"
+msgstr ""
+
+#: Model/Permission.php:195
+msgid "Invalid permission key \"%s\""
+msgstr ""
+
+#: Model/Behavior/AclBehavior.php:66
+msgid "Callback %s not defined in %s"
+msgstr ""
+
+#: Model/Behavior/AclBehavior.php:83
+msgid "AclBehavior is setup with more then one type, please specify type parameter for node()"
+msgstr ""
+
+#: Model/Behavior/ContainableBehavior.php:342
+msgid "Model \"%s\" is not associated with model \"%s\""
+msgstr ""
+
+#: Model/Behavior/TranslateBehavior.php:71
+msgid "Datasource %s for TranslateBehavior of model %s is not connected"
+msgstr ""
+
+#: Model/Behavior/TranslateBehavior.php:606
+msgid "You cannot bind a translation named \"name\"."
+msgstr ""
+
+#: Model/Behavior/TranslateBehavior.php:628
+msgid "Association %s is already bound to model %s"
+msgstr ""
+
+#: Model/Datasource/CakeSession.php:516
+msgid "Unable to configure the session, setting %s failed."
+msgstr ""
+
+#: Model/Datasource/CakeSession.php:575
+msgid "Could not load %s to handle the session."
+msgstr ""
+
+#: Model/Datasource/CakeSession.php:581
+msgid "Chosen SessionHandler does not implement CakeSessionHandlerInterface it cannot be used with an engine key."
+msgstr ""
+
+#: Model/Datasource/DboSource.php:255
+msgid "Selected driver is not enabled"
+msgstr ""
+
+#: Model/Datasource/DboSource.php:1263
+msgid "Error in Model %s"
+msgstr ""
+
+#: Model/Datasource/DboSource.php:3217
+msgid "Invalid schema object"
+msgstr ""
+
+#: Model/Datasource/DboSource.php:3327
+#: Model/Datasource/Database/Sqlite.php:407
+msgid "Column name or type not defined in schema"
+msgstr ""
+
+#: Model/Datasource/DboSource.php:3332
+#: Model/Datasource/Database/Sqlite.php:412
+msgid "Column type %s does not exist"
+msgstr ""
+
+#: Model/Datasource/Database/Mysql.php:342
+#: Model/Datasource/Database/Sqlserver.php:227
+msgid "Could not describe table for %s"
+msgstr ""
+
+#: Model/Validator/CakeValidationRule.php:281
+msgid "Could not find validation handler %s for %s"
+msgstr ""
+
+#: Network/CakeRequest.php:449
+msgid "Method %s does not exist"
+msgstr ""
+
+#: Network/CakeResponse.php:632
+msgid "Unknown status code"
+msgstr ""
+
+#: Network/CakeResponse.php:676
+msgid "Invalid status code"
+msgstr ""
+
+#: Network/CakeResponse.php:1340
+msgid "The requested file contains `..` and will not be read."
+msgstr ""
+
+#: Network/CakeResponse.php:1353
+msgid "The requested file %s was not found or not readable"
+msgstr ""
+
+#: Network/CakeSocket.php:301
+msgid "Connection timed out"
+msgstr ""
+
+#: Network/CakeSocket.php:368
+msgid "Invalid encryption scheme chosen"
+msgstr ""
+
+#: Network/CakeSocket.php:382
+msgid "Unable to perform enableCrypto operation on CakeSocket"
+msgstr ""
+
+#: Network/Email/CakeEmail.php:375
+msgid "From requires only 1 email address."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:391
+msgid "Sender requires only 1 email address."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:407
+msgid "Reply-To requires only 1 email address."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:423
+msgid "Disposition-Notification-To requires only 1 email address."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:439
+msgid "Return-Path requires only 1 email address."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:614
+msgid "Invalid email: \"%s\""
+msgstr ""
+
+#: Network/Email/CakeEmail.php:692;707
+msgid "$headers should be an array."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:919
+msgid "Format not available."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:954
+msgid "Class \"%s\" not found."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:956
+msgid "The \"%s\" does not have a %s method."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:977
+msgid "Invalid format for Message-ID. The text should be something like \"<uuid@server.com>\""
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1056
+msgid "No file or data specified."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1059
+msgid "No filename specified."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1066
+msgid "File not found: \"%s\""
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1149
+msgid "From is not specified."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1152
+msgid "You need to specify at least one destination for to, cc or bcc."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1227
+msgid "%s not found."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1231
+msgid "Unknown email configuration \"%s\"."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:155
+msgid "Unable to connect to SMTP server."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:176
+msgid "SMTP server did not accept the connection or trying to connect to non TLS SMTP server using TLS."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:181
+msgid "SMTP server did not accept the connection."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:199
+msgid "SMTP server did not accept the username."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:204
+msgid "SMTP server did not accept the password."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:207
+msgid "SMTP authentication method not allowed, check if SMTP server requires TLS."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:209
+msgid "AUTH command not recognized or not implemented, SMTP server may not require authentication."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:360
+msgid "SMTP timeout."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:373
+msgid "SMTP Error: %s"
+msgstr ""
+
+#: Network/Http/HttpResponse.php:21
+msgid "HttpResponse is deprecated due to naming conflicts. Use HttpSocketResponse instead."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:244
+msgid "Invalid resource."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:410
+msgid "Class %s not found."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:635
+msgid "Unknown authentication method."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:638
+msgid "The %s does not support authentication."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:664
+msgid "Unknown authentication method for proxy."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:667
+msgid "The %s does not support proxy authentication."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:918
+msgid "HttpSocket::_buildRequestLine - Passed an invalid request line string. Activate quirks mode to do this."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:936
+msgid "HttpSocket::_buildRequestLine - The \"*\" asterisk character is only allowed for the following methods: %s. Activate quirks mode to work outside of HTTP/1.1 specs."
+msgstr ""
+
+#: Network/Http/HttpSocketResponse.php:151
+msgid "Invalid response."
+msgstr ""
+
+#: Network/Http/HttpSocketResponse.php:155
+msgid "Invalid HTTP response."
+msgstr ""
+
+#: Routing/Router.php:233
+msgid "Route class not found, or route class is not a subclass of CakeRoute"
+msgstr ""
+
+#: Utility/CakeNumber.php:163
+msgid "No unit type."
+msgstr ""
+
+#: Utility/ClassRegistry.php:117
+msgid "(ClassRegistry::init() Attempted to create instance of a class with a numeric name"
+msgstr ""
+
+#: Utility/ClassRegistry.php:149
+msgid "Cannot create instance of %s, as it is abstract or is an interface"
+msgstr ""
+
+#: Utility/Debugger.php:630
+msgid "Invalid Debugger output format."
+msgstr ""
+
+#: Utility/Debugger.php:846
+msgid "Please change the value of %s in %s to a salt value specific to your application."
+msgstr ""
+
+#: Utility/Debugger.php:850
+msgid "Please change the value of %s in %s to a numeric (digits only) seed value specific to your application."
+msgstr ""
+
+#: Utility/Folder.php:409;432
+msgid "%s changed to %s"
+msgstr ""
+
+#: Utility/Folder.php:413;434
+msgid "%s NOT changed to %s"
+msgstr ""
+
+#: Utility/Folder.php:537
+msgid "%s is a file"
+msgstr ""
+
+#: Utility/Folder.php:548;732
+msgid "%s created"
+msgstr ""
+
+#: Utility/Folder.php:552
+msgid "%s NOT created"
+msgstr ""
+
+#: Utility/Folder.php:624;632;644
+msgid "%s removed"
+msgstr ""
+
+#: Utility/Folder.php:626;634;646
+msgid "%s NOT removed"
+msgstr ""
+
+#: Utility/Folder.php:690
+msgid "%s not found"
+msgstr ""
+
+#: Utility/Folder.php:699
+msgid "%s not writable"
+msgstr ""
+
+#: Utility/Folder.php:715
+msgid "%s copied to %s"
+msgstr ""
+
+#: Utility/Folder.php:717
+msgid "%s NOT copied to %s"
+msgstr ""
+
+#: Utility/Folder.php:736
+msgid "%s not created"
+msgstr ""
+
+#: Utility/Hash.php:53
+msgid "Invalid Parameter %s, should be dot separated path or array."
+msgstr ""
+
+#: Utility/Hash.php:414
+msgid "Hash::combine() needs an equal number of keys + values."
+msgstr ""
+
+#: Utility/Hash.php:1081
+msgid "Invalid data array to nest."
+msgstr ""
+
+#: Utility/ObjectCollection.php:124
+msgid "Cannot use modParams with indexes that do not exist."
+msgstr ""
+
+#: Utility/Security.php:159
+msgid "Invalid value, cost must be between %s and %s"
+msgstr ""
+
+#: Utility/Security.php:186;219
+msgid "You cannot use an empty key for %s"
+msgstr ""
+
+#: Utility/Security.php:223
+msgid "You must specify the operation for Security::rijndael(), either encrypt or decrypt"
+msgstr ""
+
+#: Utility/Security.php:227
+msgid "You must use a key larger than 32 bytes for Security::rijndael()"
+msgstr ""
+
+#: Utility/Security.php:286
+msgid "Invalid salt: %s for %s Please visit http://www.php.net/crypt and read the appropriate section for building %s salts."
+msgstr ""
+
+#: Utility/Security.php:339
+msgid "Invalid key for %s, key must be at least 256 bits (32 bytes) long."
+msgstr ""
+
+#: Utility/Security.php:355
+msgid "The data to decrypt cannot be empty."
+msgstr ""
+
+#: Utility/Validation.php:272
+msgid "You must define the $operator parameter for %s"
+msgstr ""
+
+#: Utility/Validation.php:290
+msgid "You must define a regular expression for %s"
+msgstr ""
+
+#: Utility/Validation.php:869
+msgid "Could not find %s class, unable to complete validation."
+msgstr ""
+
+#: Utility/Validation.php:873
+msgid "Method %s does not exist on %s unable to complete validation."
+msgstr ""
+
+#: Utility/Validation.php:967
+msgid "Can not determine the mimetype."
+msgstr ""
+
+#: Utility/Xml.php:108;112;117
+msgid "XML cannot be read."
+msgstr ""
+
+#: Utility/Xml.php:115;194
+msgid "Invalid input."
+msgstr ""
+
+#: Utility/Xml.php:149
+msgid "Xml cannot be read."
+msgstr ""
+
+#: Utility/Xml.php:198
+msgid "The key of input must be alphanumeric"
+msgstr ""
+
+#: Utility/Xml.php:275;288
+msgid "Invalid array"
+msgstr ""
+
+#: Utility/Xml.php:339
+msgid "The input is not instance of SimpleXMLElement, DOMDocument or DOMNode."
+msgstr ""
+
+#: View/Helper.php:192
+msgid "Method %1$s::%2$s does not exist"
+msgstr ""
+
+#: View/View.php:425
+msgid "Element Not Found: %s"
+msgstr ""
+
+#: View/View.php:731
+msgid "You cannot extend an element which does not exist (%s)."
+msgstr ""
+
+#: View/View.php:747
+msgid "You cannot have views extend themselves."
+msgstr ""
+
+#: View/View.php:750
+msgid "You cannot have views extend in a loop."
+msgstr ""
+
+#: View/View.php:942
+msgid "The \"%s\" block was left open. Blocks are not allowed to cross files."
+msgstr ""
+
+#: View/Elements/sql_dump.ctp:81
+msgid "Encountered unexpected %s. Cannot generate SQL log."
+msgstr ""
+
+#: View/Errors/fatal_error.ctp:18
+msgid "Fatal Error"
+msgstr ""
+
+#: View/Errors/fatal_error.ctp:20
+#: View/Errors/missing_action.ctp:19;23
+#: View/Errors/missing_behavior.ctp:21;25
+#: View/Errors/missing_component.ctp:21;25
+#: View/Errors/missing_connection.ctp:19;30
+#: View/Errors/missing_controller.ctp:21;25
+#: View/Errors/missing_database.ctp:19;23
+#: View/Errors/missing_datasource.ctp:21
+#: View/Errors/missing_datasource_config.ctp:19
+#: View/Errors/missing_helper.ctp:21;25
+#: View/Errors/missing_layout.ctp:19
+#: View/Errors/missing_plugin.ctp:19;23
+#: View/Errors/missing_table.ctp:19
+#: View/Errors/missing_view.ctp:19
+#: View/Errors/pdo_error.ctp:19
+#: View/Errors/private_action.ctp:19
+#: View/Errors/scaffold_error.ctp:19
+msgid "Error"
+msgstr ""
+
+#: View/Errors/fatal_error.ctp:24
+msgid "File"
+msgstr ""
+
+#: View/Errors/fatal_error.ctp:28
+msgid "Line"
+msgstr ""
+
+#: View/Errors/fatal_error.ctp:32
+#: View/Errors/missing_action.ctp:38
+#: View/Errors/missing_behavior.ctp:35
+#: View/Errors/missing_component.ctp:35
+#: View/Errors/missing_connection.ctp:35
+#: View/Errors/missing_controller.ctp:35
+#: View/Errors/missing_database.ctp:27
+#: View/Errors/missing_datasource.ctp:28
+#: View/Errors/missing_datasource_config.ctp:23
+#: View/Errors/missing_helper.ctp:35
+#: View/Errors/missing_layout.ctp:40
+#: View/Errors/missing_plugin.ctp:39
+#: View/Errors/missing_table.ctp:23
+#: View/Errors/missing_view.ctp:40
+#: View/Errors/pdo_error.ctp:33
+#: View/Errors/private_action.ctp:23
+#: View/Errors/scaffold_error.ctp:23
+msgid "Notice"
+msgstr ""
+
+#: View/Errors/fatal_error.ctp:33
+#: View/Errors/missing_action.ctp:39
+#: View/Errors/missing_behavior.ctp:36
+#: View/Errors/missing_component.ctp:36
+#: View/Errors/missing_connection.ctp:36
+#: View/Errors/missing_controller.ctp:36
+#: View/Errors/missing_database.ctp:28
+#: View/Errors/missing_datasource.ctp:29
+#: View/Errors/missing_datasource_config.ctp:24
+#: View/Errors/missing_helper.ctp:36
+#: View/Errors/missing_layout.ctp:41
+#: View/Errors/missing_plugin.ctp:40
+#: View/Errors/missing_table.ctp:24
+#: View/Errors/missing_view.ctp:41
+#: View/Errors/pdo_error.ctp:34
+#: View/Errors/private_action.ctp:24
+#: View/Errors/scaffold_error.ctp:24
+msgid "If you want to customize this error message, create %s"
+msgstr ""
+
+#: View/Errors/missing_action.ctp:18
+msgid "Missing Method in %s"
+msgstr ""
+
+#: View/Errors/missing_action.ctp:20
+msgid "The action %1$s is not defined in controller %2$s"
+msgstr ""
+
+#: View/Errors/missing_action.ctp:24
+msgid "Create %1$s%2$s in file: %3$s."
+msgstr ""
+
+#: View/Errors/missing_behavior.ctp:19
+msgid "Missing Behavior"
+msgstr ""
+
+#: View/Errors/missing_behavior.ctp:22
+#: View/Errors/missing_component.ctp:22
+#: View/Errors/missing_controller.ctp:22
+#: View/Errors/missing_helper.ctp:22
+msgid "%s could not be found."
+msgstr ""
+
+#: View/Errors/missing_behavior.ctp:26
+#: View/Errors/missing_component.ctp:26
+#: View/Errors/missing_controller.ctp:26
+#: View/Errors/missing_helper.ctp:26
+msgid "Create the class %s below in file: %s"
+msgstr ""
+
+#: View/Errors/missing_component.ctp:19
+msgid "Missing Component"
+msgstr ""
+
+#: View/Errors/missing_connection.ctp:17
+#: View/Errors/missing_database.ctp:17
+msgid "Missing Database Connection"
+msgstr ""
+
+#: View/Errors/missing_connection.ctp:20
+msgid "A Database connection using \"%s\" was missing or unable to connect."
+msgstr ""
+
+#: View/Errors/missing_connection.ctp:24
+msgid "The database server returned this error: %s"
+msgstr ""
+
+#: View/Errors/missing_connection.ctp:31
+msgid "%s driver is NOT enabled"
+msgstr ""
+
+#: View/Errors/missing_controller.ctp:19
+msgid "Missing Controller"
+msgstr ""
+
+#: View/Errors/missing_database.ctp:20
+msgid "Scaffold requires a database connection"
+msgstr ""
+
+#: View/Errors/missing_database.ctp:24
+#: View/Errors/missing_layout.ctp:24
+#: View/Errors/missing_view.ctp:24
+msgid "Confirm you have created the file: %s"
+msgstr ""
+
+#: View/Errors/missing_datasource.ctp:19
+msgid "Missing Datasource"
+msgstr ""
+
+#: View/Errors/missing_datasource.ctp:22
+msgid "Datasource class %s could not be found."
+msgstr ""
+
+#: View/Errors/missing_datasource_config.ctp:17
+msgid "Missing Datasource Configuration"
+msgstr ""
+
+#: View/Errors/missing_datasource_config.ctp:20
+msgid "The datasource configuration %1$s was not found in database.php."
+msgstr ""
+
+#: View/Errors/missing_helper.ctp:19
+msgid "Missing Helper"
+msgstr ""
+
+#: View/Errors/missing_layout.ctp:17
+msgid "Missing Layout"
+msgstr ""
+
+#: View/Errors/missing_layout.ctp:20
+msgid "The layout file %s can not be found or does not exist."
+msgstr ""
+
+#: View/Errors/missing_plugin.ctp:17
+msgid "Missing Plugin"
+msgstr ""
+
+#: View/Errors/missing_plugin.ctp:20
+msgid "The application is trying to load a file from the %s plugin"
+msgstr ""
+
+#: View/Errors/missing_plugin.ctp:24
+msgid "Make sure your plugin %s is in the %s directory and was loaded"
+msgstr ""
+
+#: View/Errors/missing_plugin.ctp:32
+msgid "Loading all plugins"
+msgstr ""
+
+#: View/Errors/missing_plugin.ctp:33
+msgid "If you wish to load all plugins at once, use the following line in your %s file"
+msgstr ""
+
+#: View/Errors/missing_table.ctp:17
+msgid "Missing Database Table"
+msgstr ""
+
+#: View/Errors/missing_table.ctp:20
+msgid "Table %1$s for model %2$s was not found in datasource %3$s."
+msgstr ""
+
+#: View/Errors/missing_view.ctp:17
+msgid "Missing View"
+msgstr ""
+
+#: View/Errors/missing_view.ctp:20
+msgid "The view for %1$s%2$s was not found."
+msgstr ""
+
+#: View/Errors/pdo_error.ctp:17
+msgid "Database Error"
+msgstr ""
+
+#: View/Errors/pdo_error.ctp:24
+msgid "SQL Query"
+msgstr ""
+
+#: View/Errors/pdo_error.ctp:29
+msgid "SQL Query Params"
+msgstr ""
+
+#: View/Errors/private_action.ctp:17
+msgid "Private Method in %s"
+msgstr ""
+
+#: View/Errors/private_action.ctp:20
+msgid "%s%s cannot be accessed directly."
+msgstr ""
+
+#: View/Errors/scaffold_error.ctp:17
+msgid "Scaffold Error"
+msgstr ""
+
+#: View/Errors/scaffold_error.ctp:20
+msgid "Method _scaffoldError in was not found in the controller"
+msgstr ""
+
+#: View/Helper/CacheHelper.php:161
+msgid "Unable to write view cache file: \"%s\" for \"%s\""
+msgstr ""
+
+#: View/Helper/FormHelper.php:1627
+msgid "Missing field name for FormHelper::%s"
+msgstr ""
+
+#: View/Helper/HtmlHelper.php:1235
+msgid "Cannot load the configuration file. Wrong \"configFile\" configuration."
+msgstr ""
+
+#: View/Helper/HtmlHelper.php:1241
+msgid "Cannot load the configuration file. Unknown reader."
+msgstr ""
+
+#: View/Helper/JsHelper.php:152
+msgid "JsHelper:: Missing Method %s is undefined"
+msgstr ""
+
+#: View/Helper/MootoolsEngineHelper.php:311
+msgid "%s requires a \"drag\" option to properly function"
+msgstr ""
+
+#: View/Helper/NumberHelper.php:63
+#: View/Helper/TextHelper.php:78
+#: View/Helper/TimeHelper.php:61
+msgid "%s could not be found"
+msgstr ""
+
+#: View/Helper/PaginatorHelper.php:99
+msgid "%s does not implement a %s method, it is incompatible with %s"
+msgstr ""
+

--- a/Locale/fra/LC_MESSAGES/cake.po
+++ b/Locale/fra/LC_MESSAGES/cake.po
@@ -1,372 +1,391 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: CakePHP\n"
-"POT-Creation-Date: 2012-10-22 10:52+0200\n"
-"PO-Revision-Date: \n"
-"Last-Translator: Pierre Martin <pierre@occi-tech.com>\n"
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2015-01-19 07:43+0000\n"
+"PO-Revision-Date: 2015-01-19 08:58+0100\n"
+"Last-Translator: cake17 <cake17@cake-websites.com>\n"
 "Language-Team: Cakephp-fr.org <contact@cakephp-fr.org>\n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Poedit-Language: French\n"
-"X-Poedit-Country: FRANCE\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 1.7.3\n"
+"Language: fr\n"
 
-#: Controller/Scaffold.php:128
+#: View/Errors/error400.ctp:19 View/Errors/error500.ctp:19
+msgid "Error"
+msgstr "Erreur"
+
+#: View/Errors/error400.ctp:21
+msgid "The requested address %s was not found on this server."
+msgstr "L'adresse demandée %s n'a pas été trouvée sur ce serveur."
+
+#: View/Errors/error500.ctp:20 Error/ExceptionRenderer.php:245
+msgid "An Internal Error Has Occurred."
+msgstr "Une Erreur Interne s'est produite"
+
+#: Controller/Scaffold.php:127
 msgid "Scaffold :: "
 msgstr "Scaffold :: "
 
-#: Controller/Scaffold.php:167;234;305
+#: Controller/Scaffold.php:166;233;302
 msgid "Invalid %s"
-msgstr "%s invalide"
+msgstr "%s Invalide"
 
-#: Controller/Scaffold.php:222
+#: Controller/Scaffold.php:221
 msgid "updated"
 msgstr "mis à jour"
 
-#: Controller/Scaffold.php:225
+#: Controller/Scaffold.php:224
 msgid "saved"
 msgstr "sauvegardé"
 
-#: Controller/Scaffold.php:245
+#: Controller/Scaffold.php:244
 msgid "The %1$s has been %2$s"
 msgstr "Le %1$s a été %2$s"
 
-#: Controller/Scaffold.php:256
+#: Controller/Scaffold.php:254
 msgid "Please correct errors below."
 msgstr "Merci de corriger les erreurs ci-dessous."
 
-#: Controller/Scaffold.php:308
+#: Controller/Scaffold.php:305
 msgid "The %1$s with id: %2$s has been deleted."
 msgstr "Le %1$s ayant pour id : %2$d a été supprimé."
 
-#: Controller/Scaffold.php:311
+#: Controller/Scaffold.php:308
 msgid "There was an error deleting the %1$s with id: %2$s"
-msgstr "Une erreur est survenue lors de la suppression de %1$s ayant pour id : %2$d"
+msgstr "Une erreur est survenue lors de la suppression de %1$s ayant pour id : %2$s"
 
-#: Controller/Component/AuthComponent.php:366
+#: Controller/Component/AuthComponent.php:432
 msgid "You are not authorized to access that location."
 msgstr "Vous n'êtes pas autorisé à accéder à cet endroit."
 
-#: Error/ExceptionRenderer.php:205
+#: Error/ExceptionRenderer.php:222
 msgid "Not Found"
 msgstr "Introuvable"
 
-#: Error/ExceptionRenderer.php:227
-msgid "An Internal Error Has Occurred."
-msgstr "Une erreur interne s'est produite."
-
-#: Model/Validator/CakeValidationSet.php:283
+#: Model/Validator/CakeValidationSet.php:286
 msgid "This field cannot be left blank"
 msgstr "Ce champ ne peut être vide"
 
-#: Network/CakeResponse.php:1217
+#: Network/CakeResponse.php:1355
 msgid "The requested file was not found"
 msgstr "Le fichier demandé est introuvable"
 
-#: Utility/CakeNumber.php:94
-msgid "%d KB"
-msgstr "%d Ko"
+#: Utility/CakeNumber.php:119
+msgid "%s KB"
+msgstr "%s Ko"
 
-#: Utility/CakeNumber.php:96
-msgid "%.2f MB"
-msgstr "%.2f Mo"
+#: Utility/CakeNumber.php:121
+msgid "%s MB"
+msgstr "%s Mo"
 
-#: Utility/CakeNumber.php:98
-msgid "%.2f GB"
-msgstr "%.2f Go"
+#: Utility/CakeNumber.php:123
+msgid "%s GB"
+msgstr "%s Go"
 
-#: Utility/CakeNumber.php:100
-msgid "%.2f TB"
-msgstr "%.2f To"
+#: Utility/CakeNumber.php:125
+msgid "%s TB"
+msgstr "%s To"
 
-#: Utility/CakeNumber.php:92
+#: Utility/CakeNumber.php:117
 msgid "%d Byte"
 msgid_plural "%d Bytes"
 msgstr[0] "%d Octet"
 msgstr[1] "%d Octets"
 
-#: Utility/CakeTime.php:383
+#: Utility/CakeTime.php:397
 msgid "Today, %s"
 msgstr "Aujourd'hui, %s"
 
-#: Utility/CakeTime.php:386
+#: Utility/CakeTime.php:400
 msgid "Yesterday, %s"
 msgstr "Hier, %s"
 
-#: Utility/CakeTime.php:389
+#: Utility/CakeTime.php:403
 msgid "Tomorrow, %s"
 msgstr "Demain, %s"
 
-#: Utility/CakeTime.php:394
+#: Utility/CakeTime.php:408
 msgid "Sunday"
 msgstr "Dimanche"
 
-#: Utility/CakeTime.php:395
+#: Utility/CakeTime.php:409
 msgid "Monday"
 msgstr "Lundi"
 
-#: Utility/CakeTime.php:396
+#: Utility/CakeTime.php:410
 msgid "Tuesday"
 msgstr "Mardi"
 
-#: Utility/CakeTime.php:397
+#: Utility/CakeTime.php:411
 msgid "Wednesday"
 msgstr "Mercredi"
 
-#: Utility/CakeTime.php:398
+#: Utility/CakeTime.php:412
 msgid "Thursday"
 msgstr "Jeudi"
 
-#: Utility/CakeTime.php:399
+#: Utility/CakeTime.php:413
 msgid "Friday"
 msgstr "Vendredi"
 
-#: Utility/CakeTime.php:400
+#: Utility/CakeTime.php:414
 msgid "Saturday"
 msgstr "Samedi"
 
-#: Utility/CakeTime.php:406
+#: Utility/CakeTime.php:420
 msgid "On %s %s"
 msgstr "Le %s %s"
 
-#: Utility/CakeTime.php:799
-msgid "just now"
-msgstr "à l'instant"
-
-#: Utility/CakeTime.php:803
-msgid "on %s"
-msgstr "le %s"
-
-#: Utility/CakeTime.php:847
+#: Utility/CakeTime.php:743
 msgid "%s ago"
 msgstr "il y a %s"
 
-#: Utility/CakeTime.php:866;888
+#: Utility/CakeTime.php:744
+msgid "in %s"
+msgstr "dans %s"
+
+#: Utility/CakeTime.php:745
+msgid "on %s"
+msgstr "le %s"
+
+#: Utility/CakeTime.php:801
+msgid "just now"
+msgstr "à l'instant"
+
+#: Utility/CakeTime.php:924
+msgid "in about a second"
+msgstr "dans environ une seconde"
+
+#: Utility/CakeTime.php:925
+msgid "in about a minute"
+msgstr "dans environ une minute"
+
+#: Utility/CakeTime.php:926
+msgid "in about an hour"
+msgstr "dans environ une heure"
+
+#: Utility/CakeTime.php:927
+msgid "in about a day"
+msgstr "dans environ un jour"
+
+#: Utility/CakeTime.php:928
+msgid "in about a week"
+msgstr "dans environ une semaine"
+
+#: Utility/CakeTime.php:929
+msgid "in about a year"
+msgstr "dans environ un an"
+
+#: Utility/CakeTime.php:933
+msgid "about a second ago"
+msgstr "il y a environ une seconde"
+
+#: Utility/CakeTime.php:934
+msgid "about a minute ago"
+msgstr "il y a environ une minute"
+
+#: Utility/CakeTime.php:935
+msgid "about an hour ago"
+msgstr "il y a environ une heure"
+
+#: Utility/CakeTime.php:936
+msgid "about a day ago"
+msgstr "il y a environ un jour"
+
+#: Utility/CakeTime.php:937
+msgid "about a week ago"
+msgstr "il y a environ une semaine"
+
+#: Utility/CakeTime.php:938
+msgid "about a year ago"
+msgstr "il y a environ un an"
+
+#: Utility/CakeTime.php:958;980
 msgid "days"
-msgstr "jours"
+msgstr jours
 
-# Utilisé dans Time Helper
-#: Utility/CakeTime.php:148
-msgid "abday"
-msgstr ""
-
-#: Utility/CakeTime.php:154
-msgid "day"
-msgstr "jour"
-
-# Utilisé dans Time Helper
-#: Utility/CakeTime.php:160
-msgid "d_t_fmt"
-msgstr ""
-
-# Utilisé dans Time Helper
-#: Utility/CakeTime.php:182
-msgid "abmon"
-msgstr ""
-
-#: Utility/CakeTime.php:188
-msgid "mon"
-msgstr "mois"
-
-# Utilisé dans Time Helper
-#: Utility/CakeTime.php:199
-msgid "am_pm"
-msgstr ""
-
-# Utilisé dans Time Helper
-#: Utility/CakeTime.php:206
-msgid "t_fmt_ampm"
-msgstr ""
-
-# Utilisé dans Time Helper
-#: Utility/CakeTime.php:220
-msgid "d_fmt"
-msgstr ""
-
-# Utilisé dans Time Helper
-#: Utility/CakeTime.php:226
-msgid "t_fmt"
-msgstr ""
-
-#: Utility/CakeTime.php:825
+#: Utility/CakeTime.php:895
 msgid "%d year"
 msgid_plural "%d years"
-msgstr[0] "%d année"
-msgstr[1] "%d années"
+msgstr[0] "%d an"
+msgstr[1] "%d ans"
 
-#: Utility/CakeTime.php:828
+#: Utility/CakeTime.php:898
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d mois"
 msgstr[1] "%d mois"
 
-#: Utility/CakeTime.php:831
+#: Utility/CakeTime.php:901
 msgid "%d week"
 msgid_plural "%d weeks"
 msgstr[0] "%d semaine"
 msgstr[1] "%d semaines"
 
-#: Utility/CakeTime.php:834
+#: Utility/CakeTime.php:904
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d jour"
 msgstr[1] "%d jours"
 
-#: Utility/CakeTime.php:837
+#: Utility/CakeTime.php:907
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d heure"
 msgstr[1] "%d heures"
 
-#: Utility/CakeTime.php:840
+#: Utility/CakeTime.php:910
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d minute"
 msgstr[1] "%d minutes"
 
-#: Utility/CakeTime.php:843
+#: Utility/CakeTime.php:913
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d seconde"
 msgstr[1] "%d secondes"
 
-#: View/Helper/FormHelper.php:677
+#: Utility/String.php:701
+msgid "and"
+msgstr "et"
+
+#: View/Helper/FormHelper.php:732
 msgid "Error in field %s"
 msgstr "Erreur dans le champ %s"
 
-#: View/Helper/FormHelper.php:856
-#: View/Scaffolds/form.ctp:44
-#: View/Scaffolds/index.ctp:80;87
-#: View/Scaffolds/view.ctp:51;58;142
+#: View/Helper/FormHelper.php:921 View/Scaffolds/form.ctp:46
+#: View/Scaffolds/index.ctp:77;92 View/Scaffolds/view.ctp:63;78;188
 msgid "New %s"
 msgstr "Nouveau %s"
 
-#: View/Helper/FormHelper.php:862
-#: View/Scaffolds/view.ctp:48;85
+#: View/Helper/FormHelper.php:927 View/Scaffolds/view.ctp:51;109
 msgid "Edit %s"
-msgstr "Editer %s"
+msgstr "Modifier %s"
 
-#: View/Helper/FormHelper.php:1683
-#: View/Scaffolds/form.ctp:23
+#: View/Helper/FormHelper.php:1500
+msgid "empty"
+msgstr "vide"
+
+#: View/Helper/FormHelper.php:1895 View/Scaffolds/form.ctp:21
 msgid "Submit"
 msgstr "Envoyer"
 
-#: View/Helper/FormHelper.php:2573
+#: View/Helper/FormHelper.php:2874
 msgid "January"
 msgstr "Janvier"
 
-#: View/Helper/FormHelper.php:2574
+#: View/Helper/FormHelper.php:2875
 msgid "February"
 msgstr "Février"
 
-#: View/Helper/FormHelper.php:2575
+#: View/Helper/FormHelper.php:2876
 msgid "March"
 msgstr "Mars"
 
-#: View/Helper/FormHelper.php:2576
+#: View/Helper/FormHelper.php:2877
 msgid "April"
 msgstr "Avril"
 
-#: View/Helper/FormHelper.php:2577
+#: View/Helper/FormHelper.php:2878
 msgid "May"
 msgstr "Mai"
 
-#: View/Helper/FormHelper.php:2578
+#: View/Helper/FormHelper.php:2879
 msgid "June"
 msgstr "Juin"
 
-#: View/Helper/FormHelper.php:2579
+#: View/Helper/FormHelper.php:2880
 msgid "July"
 msgstr "Juillet"
 
-#: View/Helper/FormHelper.php:2580
+#: View/Helper/FormHelper.php:2881
 msgid "August"
 msgstr "Août"
 
-#: View/Helper/FormHelper.php:2581
+#: View/Helper/FormHelper.php:2882
 msgid "September"
 msgstr "Septembre"
 
-#: View/Helper/FormHelper.php:2582
+#: View/Helper/FormHelper.php:2883
 msgid "October"
 msgstr "Octobre"
 
-#: View/Helper/FormHelper.php:2583
+#: View/Helper/FormHelper.php:2884
 msgid "November"
 msgstr "Novembre"
 
-#: View/Helper/FormHelper.php:2584
+#: View/Helper/FormHelper.php:2885
 msgid "December"
 msgstr "Décembre"
 
-#: View/Helper/PaginatorHelper.php:581
+#: View/Helper/HtmlHelper.php:782
+msgid "Home"
+msgstr "Accueil"
+
+#: View/Helper/PaginatorHelper.php:637
 msgid " of "
 msgstr " de "
 
-#: View/Scaffolds/form.ctp:27
-#: View/Scaffolds/index.ctp:26;78
-#: View/Scaffolds/view.ctp:45
+#: View/Scaffolds/form.ctp:25 View/Scaffolds/index.ctp:24;75
+#: View/Scaffolds/view.ctp:47
 msgid "Actions"
 msgstr "Actions"
 
-#: View/Scaffolds/form.ctp:31
-#: View/Scaffolds/index.ctp:52
-#: View/Scaffolds/view.ctp:133
+#: View/Scaffolds/form.ctp:29 View/Scaffolds/index.ctp:49
+#: View/Scaffolds/view.ctp:173
 msgid "Delete"
 msgstr "Supprimer"
 
-#: View/Scaffolds/form.ctp:34
+#: View/Scaffolds/form.ctp:32 View/Scaffolds/index.ctp:52
+#: View/Scaffolds/view.ctp:55;176
 msgid "Are you sure you want to delete # %s?"
 msgstr "Êtes vous sûr de vouloir supprimer # %s ?"
 
-#: View/Scaffolds/form.ctp:37
+#: View/Scaffolds/form.ctp:35
 msgid "List"
 msgstr "Lister"
 
-#: View/Scaffolds/form.ctp:43
-#: View/Scaffolds/index.ctp:86
-#: View/Scaffolds/view.ctp:50;57
+#: View/Scaffolds/form.ctp:42 View/Scaffolds/index.ctp:85
+#: View/Scaffolds/view.ctp:59;72
 msgid "List %s"
 msgstr "Lister %s"
 
-#: View/Scaffolds/index.ctp:49
-#: View/Scaffolds/view.ctp:131
+#: View/Scaffolds/index.ctp:46 View/Scaffolds/view.ctp:161
 msgid "View"
 msgstr "Voir"
 
-#: View/Scaffolds/index.ctp:50
-#: View/Scaffolds/view.ctp:132
+#: View/Scaffolds/index.ctp:47 View/Scaffolds/view.ctp:167
 msgid "Edit"
 msgstr "Modifier"
 
-#: View/Scaffolds/index.ctp:55
-#: View/Scaffolds/view.ctp:49;133
-msgid "Are you sure you want to delete"
-msgstr "Etes-vous sûr de vouloir supprimer"
-
-#: View/Scaffolds/index.ctp:66
-msgid "Page {:page} of {:pages}, showing {:current} records out of {:count} total, starting on record {:start}, ending on {:end}"
+#: View/Scaffolds/index.ctp:63
+msgid ""
+"Page {:page} of {:pages}, showing {:current} records out of {:count} total, "
+"starting on record {:start}, ending on {:end}"
 msgstr "Page {:page} de {:pages}, {:current} enregistrements sur un total de {:count}, à partir de l'enregistrement {:start}, jusqu'au {:end}"
 
-#: View/Scaffolds/index.ctp:71
+#: View/Scaffolds/index.ctp:68
 msgid "previous"
 msgstr "précédent"
 
-#: View/Scaffolds/index.ctp:73
+#: View/Scaffolds/index.ctp:70
 msgid "next"
 msgstr "suivant"
 
-#: View/Scaffolds/view.ctp:20
+#: View/Scaffolds/view.ctp:18
 msgid "View %s"
 msgstr "Voir %s"
 
-#: View/Scaffolds/view.ctp:49
+#: View/Scaffolds/view.ctp:55
 msgid "Delete %s"
 msgstr "Supprimer %s"
 
-#: View/Scaffolds/view.ctp:70;105
+#: View/Scaffolds/view.ctp:93;133
 msgid "Related %s"
 msgstr "Lié à %s"
-

--- a/Locale/fra/LC_MESSAGES/cake_console.po
+++ b/Locale/fra/LC_MESSAGES/cake_console.po
@@ -1,0 +1,2449 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2015-01-19 07:43+0000\n"
+"PO-Revision-Date: 2015-01-19 09:48+0100\n"
+"Last-Translator: cake17 <cake17@cake-websites.com>\n"
+"Language-Team: Cakephp-fr.org <contact@cakephp-fr.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 1.7.3\n"
+"Language: fr\n"
+
+#: Console/ConsoleErrorHandler.php:57
+msgid ""
+"<error>Error:</error> %s\n"
+"%s"
+msgstr ""
+
+#: Console/ConsoleErrorHandler.php:83
+msgid "%s in [%s, line %s]"
+msgstr ""
+
+#: Console/ConsoleErrorHandler.php:84
+msgid "<error>%s Error:</error> %s\n"
+msgstr ""
+
+#: Console/ConsoleInputArgument.php:98
+msgid " <comment>(optional)</comment>"
+msgstr ""
+
+#: Console/ConsoleInputArgument.php:101 Console/ConsoleInputOption.php:130
+msgid " <comment>(choices: %s)</comment>"
+msgstr ""
+
+#: Console/ConsoleInputArgument.php:145
+msgid "\"%s\" is not a valid value for %s. Please use one of \"%s\""
+msgstr ""
+
+#: Console/ConsoleInputOption.php:95
+msgid "Short option \"%s\" is invalid, short options must be one letter."
+msgstr ""
+
+#: Console/ConsoleInputOption.php:127
+msgid " <comment>(default: %s)</comment>"
+msgstr ""
+
+#: Console/ConsoleInputOption.php:190
+msgid "\"%s\" is not a valid value for --%s. Please use one of \"%s\""
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:147
+msgid "Display this help."
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:154
+msgid "Enable verbose output."
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:158
+msgid "Enable quiet output."
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:493
+msgid "Missing required arguments. %s is required."
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:576
+msgid "Unknown short option `%s`"
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:592
+msgid "Unknown option `%s`"
+msgstr ""
+
+#: Console/ConsoleOptionParser.php:645
+msgid "Too many arguments."
+msgstr ""
+
+#: Console/HelpFormatter.php:70
+msgid "<info>Usage:</info>"
+msgstr ""
+
+#: Console/HelpFormatter.php:75
+msgid "<info>Subcommands:</info>"
+msgstr ""
+
+#: Console/HelpFormatter.php:86
+msgid ""
+"To see help on a subcommand use <info>`cake %s [subcommand] --help`</info>"
+msgstr ""
+
+#: Console/HelpFormatter.php:93
+msgid "<info>Options:</info>"
+msgstr ""
+
+#: Console/HelpFormatter.php:108
+msgid "<info>Arguments:</info>"
+msgstr ""
+
+#: Console/Shell.php:240 Console/Command/ServerShell.php:112
+msgid "<info>Welcome to CakePHP %s Console</info>"
+msgstr ""
+
+#: Console/Shell.php:242 Console/Command/ServerShell.php:114
+msgid "App : %s"
+msgstr ""
+
+#: Console/Shell.php:243 Console/Command/ServerShell.php:115
+#: Console/Command/Task/PluginTask.php:64
+#: Console/Command/Task/TestTask.php:112
+msgid "Path: %s"
+msgstr ""
+
+#: Console/Shell.php:706
+msgid "<error>Error:</error> %s"
+msgstr ""
+
+#: Console/Shell.php:744
+msgid "<warning>File `%s` exists</warning>"
+msgstr ""
+
+#: Console/Shell.php:745
+msgid "Do you want to overwrite?"
+msgstr ""
+
+#: Console/Shell.php:748
+msgid "<error>Quitting</error>."
+msgstr ""
+
+#: Console/Shell.php:751
+msgid "Skip `%s`"
+msgstr ""
+
+#: Console/Shell.php:755
+msgid "Creating file %s"
+msgstr ""
+
+#: Console/Shell.php:762
+msgid "<success>Wrote</success> `%s`"
+msgstr ""
+
+#: Console/Shell.php:766
+msgid "<error>Could not write to `%s`</error>."
+msgstr ""
+
+#: Console/Shell.php:786
+msgid "PHPUnit is not installed. Do you want to bake unit test files anyway?"
+msgstr ""
+
+#: Console/Shell.php:792
+msgid "You can download PHPUnit from %s"
+msgstr ""
+
+#: Console/Command/AclShell.php:77
+msgid ""
+"Error: Your current CakePHP configuration is set to an ACL implementation "
+"other than DB."
+msgstr ""
+
+#: Console/Command/AclShell.php:78
+msgid ""
+"Please change your core config to reflect your decision to use DbAcl before "
+"attempting to use this script"
+msgstr ""
+
+#: Console/Command/AclShell.php:80
+msgid "Current ACL Classname: %s"
+msgstr ""
+
+#: Console/Command/AclShell.php:88 Console/Command/BakeShell.php:88
+#: Console/Command/I18nShell.php:54
+msgid "Your database configuration was not found. Take a moment to create one."
+msgstr ""
+
+#: Console/Command/AclShell.php:133
+msgid "/ can not be used as an alias!"
+msgstr ""
+
+#: Console/Command/AclShell.php:133
+msgid "\t/ is the root, please supply a sub alias"
+msgstr ""
+
+#: Console/Command/AclShell.php:139
+msgid "<success>New %s</success> '%s' created."
+msgstr ""
+
+#: Console/Command/AclShell.php:141
+msgid "There was a problem creating a new %s '%s'."
+msgstr ""
+
+#: Console/Command/AclShell.php:161;165
+msgid "Node Not Deleted. "
+msgstr ""
+
+#: Console/Command/AclShell.php:161
+msgid "There was an error deleting the %s."
+msgstr ""
+
+#: Console/Command/AclShell.php:163
+msgid "<success>%s deleted.</success>"
+msgstr ""
+
+#: Console/Command/AclShell.php:165
+msgid "There was an error deleting the %s. Node does not exist."
+msgstr ""
+
+#: Console/Command/AclShell.php:187
+msgid ""
+"Error in setting new parent. Please make sure the parent node exists, and is "
+"not a descendant of the node specified."
+msgstr ""
+
+#: Console/Command/AclShell.php:189
+msgid "Node parent set to %s"
+msgstr ""
+
+#: Console/Command/AclShell.php:207
+msgid "Supplied Node '%s' not found"
+msgstr ""
+
+#: Console/Command/AclShell.php:208;324;326;534
+msgid "No tree returned."
+msgstr ""
+
+#: Console/Command/AclShell.php:211
+msgid "Path:"
+msgstr ""
+
+#: Console/Command/AclShell.php:245
+msgid "%s is <success>allowed</success>."
+msgstr ""
+
+#: Console/Command/AclShell.php:247
+msgid "%s is <error>not allowed</error>."
+msgstr ""
+
+#: Console/Command/AclShell.php:260
+msgid "Permission <success>granted</success>."
+msgstr ""
+
+#: Console/Command/AclShell.php:262
+msgid "Permission was <error>not granted</error>."
+msgstr ""
+
+#: Console/Command/AclShell.php:275
+msgid "Permission denied."
+msgstr ""
+
+#: Console/Command/AclShell.php:277
+msgid "Permission was not denied."
+msgstr ""
+
+#: Console/Command/AclShell.php:290
+msgid "Permission inherited."
+msgstr ""
+
+#: Console/Command/AclShell.php:292
+msgid "Permission was not inherited."
+msgstr ""
+
+#: Console/Command/AclShell.php:324;326;534 Console/Command/ApiShell.php:92
+#: Console/Command/Task/DbConfigTask.php:254
+msgid "%s not found"
+msgstr ""
+
+#: Console/Command/AclShell.php:376
+msgid "Type of node to create."
+msgstr ""
+
+#: Console/Command/AclShell.php:380
+msgid "A console tool for managing the DbAcl"
+msgstr ""
+
+#: Console/Command/AclShell.php:382
+msgid "Create a new ACL node"
+msgstr ""
+
+#: Console/Command/AclShell.php:384
+msgid "Creates a new ACL object <node> under the parent"
+msgstr ""
+
+#: Console/Command/AclShell.php:385
+msgid ""
+"You can use `root` as the parent when creating nodes to create top level "
+"nodes."
+msgstr ""
+
+#: Console/Command/AclShell.php:389
+msgid "The node selector for the parent."
+msgstr ""
+
+#: Console/Command/AclShell.php:393
+msgid "The alias to use for the newly created node."
+msgstr ""
+
+#: Console/Command/AclShell.php:399
+msgid "Deletes the ACL object with the given <node> reference"
+msgstr ""
+
+#: Console/Command/AclShell.php:401
+msgid "Delete an ACL node."
+msgstr ""
+
+#: Console/Command/AclShell.php:405
+msgid "The node identifier to delete."
+msgstr ""
+
+#: Console/Command/AclShell.php:411
+msgid "Moves the ACL node under a new parent."
+msgstr ""
+
+#: Console/Command/AclShell.php:413
+msgid "Moves the ACL object specified by <node> beneath <parent>"
+msgstr ""
+
+#: Console/Command/AclShell.php:417
+msgid "The node to move"
+msgstr ""
+
+#: Console/Command/AclShell.php:421
+msgid "The new parent for <node>."
+msgstr ""
+
+#: Console/Command/AclShell.php:427
+msgid "Print out the path to an ACL node."
+msgstr ""
+
+#: Console/Command/AclShell.php:430
+msgid "Returns the path to the ACL object specified by <node>."
+msgstr ""
+
+#: Console/Command/AclShell.php:431
+msgid ""
+"This command is useful in determining the inheritance of permissions for a "
+"certain object in the tree."
+msgstr ""
+
+#: Console/Command/AclShell.php:436
+msgid "The node to get the path of"
+msgstr ""
+
+#: Console/Command/AclShell.php:442
+msgid "Check the permissions between an ACO and ARO."
+msgstr ""
+
+#: Console/Command/AclShell.php:445
+msgid "Use this command to check ACL permissions."
+msgstr ""
+
+#: Console/Command/AclShell.php:448
+msgid "ARO to check."
+msgstr ""
+
+#: Console/Command/AclShell.php:449
+msgid "ACO to check."
+msgstr ""
+
+#: Console/Command/AclShell.php:450
+msgid "Action to check"
+msgstr ""
+
+#: Console/Command/AclShell.php:454
+msgid "Grant an ARO permissions to an ACO."
+msgstr ""
+
+#: Console/Command/AclShell.php:457
+msgid ""
+"Use this command to grant ACL permissions. Once executed, the ARO specified "
+"(and its children, if any) will have ALLOW access to the specified ACO "
+"action (and the ACO's children, if any)."
+msgstr ""
+
+#: Console/Command/AclShell.php:460
+msgid "ARO to grant permission to."
+msgstr ""
+
+#: Console/Command/AclShell.php:461
+msgid "ACO to grant access to."
+msgstr ""
+
+#: Console/Command/AclShell.php:462
+msgid "Action to grant"
+msgstr ""
+
+#: Console/Command/AclShell.php:466
+msgid "Deny an ARO permissions to an ACO."
+msgstr ""
+
+#: Console/Command/AclShell.php:469
+msgid ""
+"Use this command to deny ACL permissions. Once executed, the ARO specified "
+"(and its children, if any) will have DENY access to the specified ACO action "
+"(and the ACO's children, if any)."
+msgstr ""
+
+#: Console/Command/AclShell.php:472
+msgid "ARO to deny."
+msgstr ""
+
+#: Console/Command/AclShell.php:473
+msgid "ACO to deny."
+msgstr ""
+
+#: Console/Command/AclShell.php:474
+msgid "Action to deny"
+msgstr ""
+
+#: Console/Command/AclShell.php:478
+msgid "Inherit an ARO's parent permissions."
+msgstr ""
+
+#: Console/Command/AclShell.php:481
+msgid ""
+"Use this command to force a child ARO object to inherit its permissions "
+"settings from its parent."
+msgstr ""
+
+#: Console/Command/AclShell.php:484
+msgid "ARO to have permissions inherit."
+msgstr ""
+
+#: Console/Command/AclShell.php:485
+msgid "ACO to inherit permissions on."
+msgstr ""
+
+#: Console/Command/AclShell.php:486
+msgid "Action to inherit"
+msgstr ""
+
+#: Console/Command/AclShell.php:490
+msgid "View a tree or a single node's subtree."
+msgstr ""
+
+#: Console/Command/AclShell.php:493
+msgid "The view command will return the ARO or ACO tree."
+msgstr ""
+
+#: Console/Command/AclShell.php:494
+msgid "The optional node parameter allows you to return"
+msgstr ""
+
+#: Console/Command/AclShell.php:495
+msgid "only a portion of the requested tree."
+msgstr ""
+
+#: Console/Command/AclShell.php:499
+msgid "The optional node to view the subtree of."
+msgstr ""
+
+#: Console/Command/AclShell.php:503
+msgid ""
+"Initialize the DbAcl tables. Uses this command : cake schema create DbAcl"
+msgstr ""
+
+#: Console/Command/AclShell.php:570
+msgid "Could not find node using reference \"%s\""
+msgstr ""
+
+#: Console/Command/ApiShell.php:100
+msgid "%s::%s() could not be found"
+msgstr ""
+
+#: Console/Command/ApiShell.php:117
+msgid ""
+"Select a number to see the more information about a specific method. q to "
+"quit. l to list."
+msgstr ""
+
+#: Console/Command/ApiShell.php:119
+msgid "Done"
+msgstr ""
+
+#: Console/Command/ApiShell.php:148
+msgid "Lookup doc block comments for classes in CakePHP."
+msgstr ""
+
+#: Console/Command/ApiShell.php:150
+msgid ""
+"Either a full path or type of class (model, behavior, controller, component, "
+"view, helper)"
+msgstr ""
+
+#: Console/Command/ApiShell.php:152
+msgid "A CakePHP core class name (e.g: Component, HtmlHelper)."
+msgstr ""
+
+#: Console/Command/ApiShell.php:155
+msgid "The specific method you want help on."
+msgstr ""
+
+#: Console/Command/ApiShell.php:194
+msgid "Command %s not found"
+msgstr ""
+
+#: Console/Command/ApiShell.php:211
+msgid "%s could not be found"
+msgstr ""
+
+#: Console/Command/BakeShell.php:92
+msgid "Interactive Bake Shell"
+msgstr ""
+
+#: Console/Command/BakeShell.php:94
+msgid "[D]atabase Configuration"
+msgstr ""
+
+#: Console/Command/BakeShell.php:95
+msgid "[M]odel"
+msgstr ""
+
+#: Console/Command/BakeShell.php:96
+msgid "[V]iew"
+msgstr ""
+
+#: Console/Command/BakeShell.php:97
+msgid "[C]ontroller"
+msgstr ""
+
+#: Console/Command/BakeShell.php:98
+msgid "[P]roject"
+msgstr ""
+
+#: Console/Command/BakeShell.php:99
+msgid "[F]ixture"
+msgstr ""
+
+#: Console/Command/BakeShell.php:100
+msgid "[T]est case"
+msgstr ""
+
+#: Console/Command/BakeShell.php:101 Console/Command/I18nShell.php:71
+msgid "[Q]uit"
+msgstr ""
+
+#: Console/Command/BakeShell.php:103
+msgid "What would you like to Bake?"
+msgstr ""
+
+#: Console/Command/BakeShell.php:129
+msgid ""
+"You have made an invalid selection. Please choose a type of class to Bake by "
+"entering D, M, V, F, T, or C."
+msgstr ""
+
+#: Console/Command/BakeShell.php:197
+msgid "<success>Bake All complete</success>"
+msgstr ""
+
+#: Console/Command/BakeShell.php:200
+msgid "Bake All could not continue without a valid model"
+msgstr ""
+
+#: Console/Command/BakeShell.php:214
+msgid ""
+"The Bake script generates controllers, views and models for your "
+"application. If run with no command line arguments, Bake guides the user "
+"through the class creation process. You can customize the generation process "
+"by telling Bake where different parts of your application are using command "
+"line arguments."
+msgstr ""
+
+#: Console/Command/BakeShell.php:218
+msgid "Bake a complete MVC. optional <name> of a Model"
+msgstr ""
+
+#: Console/Command/BakeShell.php:220
+msgid ""
+"Bake a new app folder in the path supplied or in current directory if no "
+"path is specified"
+msgstr ""
+
+#: Console/Command/BakeShell.php:223
+msgid ""
+"Bake a new plugin folder in the path supplied or in current directory if no "
+"path is specified."
+msgstr ""
+
+#: Console/Command/BakeShell.php:226
+msgid "Bake a database.php file in config directory."
+msgstr ""
+
+#: Console/Command/BakeShell.php:229
+msgid "Bake a model."
+msgstr ""
+
+#: Console/Command/BakeShell.php:232
+msgid "Bake views for controllers."
+msgstr ""
+
+#: Console/Command/BakeShell.php:235
+msgid "Bake a controller."
+msgstr ""
+
+#: Console/Command/BakeShell.php:238
+msgid "Bake a fixture."
+msgstr ""
+
+#: Console/Command/BakeShell.php:241
+msgid "Bake a unit test."
+msgstr ""
+
+#: Console/Command/BakeShell.php:244
+msgid "Database connection to use in conjunction with `bake all`."
+msgstr ""
+
+#: Console/Command/BakeShell.php:249
+#: Console/Command/Task/ControllerTask.php:495
+#: Console/Command/Task/FixtureTask.php:91
+#: Console/Command/Task/ModelTask.php:1020
+#: Console/Command/Task/ProjectTask.php:443
+#: Console/Command/Task/TestTask.php:568 Console/Command/Task/ViewTask.php:438
+msgid "Theme to use when baking code."
+msgstr ""
+
+#: Console/Command/CommandListShell.php:52
+msgid "<info>Current Paths:</info>"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:58
+msgid "<info>Changing Paths:</info>"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:59
+msgid ""
+"Your working path should be the same as your application path. To change "
+"your path use the '-app' param."
+msgstr ""
+
+#: Console/Command/CommandListShell.php:60
+msgid "Example: %s or %s"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:62
+msgid "<info>Available Shells:</info>"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:90
+msgid "To run an app or core command, type <info>cake shell_name [args]</info>"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:91
+msgid ""
+"To run a plugin command, type <info>cake Plugin.shell_name [args]</info>"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:92
+msgid ""
+"To get help on a specific command, type <info>cake shell_name --help</info>"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:131
+msgid "Get the list of available shells for this CakePHP application."
+msgstr ""
+
+#: Console/Command/CommandListShell.php:133
+msgid "Does nothing (deprecated)"
+msgstr ""
+
+#: Console/Command/CommandListShell.php:136
+msgid "Get the listing as XML."
+msgstr ""
+
+#: Console/Command/CompletionShell.php:107
+msgid ""
+"Used by shells like bash to autocomplete command name, options and arguments"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:109
+msgid "Output a list of available commands"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:111
+msgid "List all availables"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:116
+msgid "Output a list of available subcommands"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:118
+msgid "List subcommands for a command"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:121;132
+msgid "The command name"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:127
+msgid "Output a list of available options"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:129
+msgid "List options"
+msgstr ""
+
+#: Console/Command/CompletionShell.php:138
+msgid "This command is not intended to be called manually"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:91;249
+msgid "Model classes:"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:99
+msgid ""
+"There was an error loading the routes config. Please check that the file "
+"exists and contains no errors."
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:211
+msgid "Invalid command"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:276
+msgid "Created %s association between %s and %s"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:279
+msgid "Please verify you are using valid models and association types"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:313
+msgid "Removed %s association between %s and %s"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:316
+msgid ""
+"Please verify you are using valid models, valid current association, and "
+"valid association types"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:375
+msgid "No result set found"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:378
+msgid "%s is not a valid model"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:402
+msgid "Saved record for %s"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:430
+msgid "Please verify that you selected a valid model"
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:441
+msgid ""
+"There was an error loading the routes config. Please check that the file "
+"exists and is free of parse errors."
+msgstr ""
+
+#: Console/Command/ConsoleShell.php:443
+msgid "Routes configuration reloaded, %d routes connected"
+msgstr ""
+
+#: Console/Command/I18nShell.php:66
+msgid "<info>I18n Shell</info>"
+msgstr ""
+
+#: Console/Command/I18nShell.php:68
+msgid "[E]xtract POT file from sources"
+msgstr ""
+
+#: Console/Command/I18nShell.php:69
+msgid "[I]nitialize i18n database table"
+msgstr ""
+
+#: Console/Command/I18nShell.php:70
+msgid "[H]elp"
+msgstr ""
+
+#: Console/Command/I18nShell.php:73
+msgid "What would you like to do?"
+msgstr ""
+
+#: Console/Command/I18nShell.php:87
+msgid ""
+"You have made an invalid selection. Please choose a command to execute by "
+"entering E, I, H, or Q."
+msgstr ""
+
+#: Console/Command/I18nShell.php:111
+msgid ""
+"I18n Shell initializes i18n database table for your application and "
+"generates .pot files(s) with translations."
+msgstr ""
+
+#: Console/Command/I18nShell.php:113
+msgid "Initialize the i18n table."
+msgstr ""
+
+#: Console/Command/I18nShell.php:115
+msgid "Extract the po translations from your application"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:109
+msgid "Schema file (%s) could not be found."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:120
+msgid "Generating Schema..."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:135
+msgid ""
+"Schema file exists.\n"
+" [O]verwrite\n"
+" [S]napshot\n"
+" [Q]uit\n"
+"Would you like to do?"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:189;192
+msgid "Schema file: %s generated"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:209
+msgid "Schema could not be loaded"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:233
+msgid "SQL dump file created in %s"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:236
+msgid "SQL dump could not be created"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:279
+msgid "Performing a dry run."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:295
+msgid ""
+"<error>Error</error>: The chosen schema could not be loaded. Attempted to "
+"load:"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:296
+msgid "- file: %s"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:297
+msgid "- name: %s"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:330;394
+msgid "Schema is up to date."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:334
+msgid "The following table(s) will be dropped."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:338
+msgid "Are you sure you want to drop the table(s)?"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:340
+msgid "Dropping table(s)."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:344
+msgid "The following table(s) will be created."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:348
+msgid "Are you sure you want to create the table(s)?"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:350
+msgid "Creating table(s)."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:353
+msgid "End create."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:367
+msgid "Comparing Database to Schema..."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:398
+msgid "The following statements will run."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:401
+msgid "Are you sure you want to alter the tables?"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:404
+msgid "Updating Database..."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:408
+msgid "End update."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:421
+msgid "Sql could not be run"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:429
+msgid "%s is up to date."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:432
+msgid "Dry run for %s :"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:450
+msgid "%s updated."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:467
+msgid "The plugin to use."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:471
+msgid "Set the db config to use."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:475
+msgid "Path to read and write schema.php"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:479
+msgid "File name to read and write."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:482
+msgid ""
+"Classname to use. If its Plugin.class, both name and plugin options will be "
+"set."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:488
+msgid "Snapshot number to use/make."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:492
+msgid "Specify models as comma separated list."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:495
+msgid ""
+"Perform a dry run on create and update commands. Queries will be output "
+"instead of run."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:502
+msgid "Force \"generate\" to create a new schema"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:506
+msgid "Write the dumped SQL to a file."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:509
+msgid "Tables to exclude as comma separated list."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:513
+msgid "Do not prompt for confirmation. Be careful!"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:518
+msgid ""
+"The Schema Shell generates a schema object from the database and updates the "
+"database from the schema."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:520
+msgid "Read and output the contents of a schema file"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:526
+msgid ""
+"Reads from --connection and writes to --path. Generate snapshots with -s"
+msgstr ""
+
+#: Console/Command/SchemaShell.php:530
+msgid "Generate a snapshot."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:534
+msgid "Dump database SQL based on a schema file to stdout."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:540
+msgid "Drop and create tables based on the schema file."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:545;558
+msgid "Name of schema to use."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:548;561
+msgid "Only create the specified table."
+msgstr ""
+
+#: Console/Command/SchemaShell.php:553
+msgid "Alter the tables based on the schema file."
+msgstr ""
+
+#: Console/Command/ServerShell.php:116
+msgid "DocumentRoot: %s"
+msgstr ""
+
+#: Console/Command/ServerShell.php:127
+msgid "<warning>This command is available on %s or above</warning>"
+msgstr ""
+
+#: Console/Command/ServerShell.php:139
+msgid "built-in server is running in http://%s%s/"
+msgstr ""
+
+#: Console/Command/ServerShell.php:152
+msgid "PHP Built-in Server for CakePHP"
+msgstr ""
+
+#: Console/Command/ServerShell.php:153
+msgid "<warning>[WARN] Don't use this at the production environment</warning>"
+msgstr ""
+
+#: Console/Command/ServerShell.php:156
+msgid "ServerHost"
+msgstr ""
+
+#: Console/Command/ServerShell.php:159
+msgid "ListenPort"
+msgstr ""
+
+#: Console/Command/ServerShell.php:162
+msgid "DocumentRoot"
+msgstr ""
+
+#: Console/Command/TestShell.php:49 Console/Command/TestsuiteShell.php:43
+msgid ""
+"The CakePHP Testsuite allows you to run test cases from the command line"
+msgstr ""
+
+#: Console/Command/TestShell.php:51
+msgid "The category for the test, or test file, to test."
+msgstr ""
+
+#: Console/Command/TestShell.php:54
+msgid "The path to the file, or test file, to test."
+msgstr ""
+
+#: Console/Command/TestShell.php:57
+msgid "<file> Log test execution in JUnit XML format to file."
+msgstr ""
+
+#: Console/Command/TestShell.php:60
+msgid "<file> Log test execution in JSON format to file."
+msgstr ""
+
+#: Console/Command/TestShell.php:63
+msgid "<file> Log test execution in TAP format to file."
+msgstr ""
+
+#: Console/Command/TestShell.php:66
+msgid "Log test execution to DBUS."
+msgstr ""
+
+#: Console/Command/TestShell.php:69
+msgid "<dir> Generate code coverage report in HTML format."
+msgstr ""
+
+#: Console/Command/TestShell.php:72
+msgid "<file> Write code coverage data in Clover XML format."
+msgstr ""
+
+#: Console/Command/TestShell.php:75
+msgid "<file> Write agile documentation in HTML format to file."
+msgstr ""
+
+#: Console/Command/TestShell.php:78
+msgid "<file> Write agile documentation in Text format to file."
+msgstr ""
+
+#: Console/Command/TestShell.php:81
+msgid "<pattern> Filter which tests to run."
+msgstr ""
+
+#: Console/Command/TestShell.php:84
+msgid "<name> Only runs tests from the specified group(s)."
+msgstr ""
+
+#: Console/Command/TestShell.php:87
+msgid "<name> Exclude tests from the specified group(s)."
+msgstr ""
+
+#: Console/Command/TestShell.php:90
+msgid "List available test groups."
+msgstr ""
+
+#: Console/Command/TestShell.php:93
+msgid "TestSuiteLoader implementation to use."
+msgstr ""
+
+#: Console/Command/TestShell.php:96
+msgid "<times> Runs the test(s) repeatedly."
+msgstr ""
+
+#: Console/Command/TestShell.php:99
+msgid "Report test execution progress in TAP format."
+msgstr ""
+
+#: Console/Command/TestShell.php:102
+msgid "Report test execution progress in TestDox format."
+msgstr ""
+
+#: Console/Command/TestShell.php:106
+msgid "Do not use colors in output."
+msgstr ""
+
+#: Console/Command/TestShell.php:109
+msgid "Write to STDERR instead of STDOUT."
+msgstr ""
+
+#: Console/Command/TestShell.php:112
+msgid "Stop execution upon first error or failure."
+msgstr ""
+
+#: Console/Command/TestShell.php:115
+msgid "Stop execution upon first failure."
+msgstr ""
+
+#: Console/Command/TestShell.php:118
+msgid "Stop execution upon first skipped test."
+msgstr ""
+
+#: Console/Command/TestShell.php:121
+msgid "Stop execution upon first incomplete test."
+msgstr ""
+
+#: Console/Command/TestShell.php:124
+msgid "Mark a test as incomplete if no assertions are made."
+msgstr ""
+
+#: Console/Command/TestShell.php:127
+msgid "Waits for a keystroke after each test."
+msgstr ""
+
+#: Console/Command/TestShell.php:130
+msgid "Run each test in a separate PHP process."
+msgstr ""
+
+#: Console/Command/TestShell.php:133
+msgid "Do not backup and restore $GLOBALS for each test."
+msgstr ""
+
+#: Console/Command/TestShell.php:136
+msgid "Backup and restore static attributes for each test."
+msgstr ""
+
+#: Console/Command/TestShell.php:139
+msgid "Try to check source files for syntax errors."
+msgstr ""
+
+#: Console/Command/TestShell.php:142
+msgid "<file> A \"bootstrap\" PHP file that is run before the tests."
+msgstr ""
+
+#: Console/Command/TestShell.php:145
+msgid "<file> Read configuration from XML file."
+msgstr ""
+
+#: Console/Command/TestShell.php:148
+msgid "Ignore default configuration file (phpunit.xml)."
+msgstr ""
+
+#: Console/Command/TestShell.php:151
+msgid "<path(s)> Prepend PHP include_path with given path(s)."
+msgstr ""
+
+#: Console/Command/TestShell.php:154
+msgid "key[=value] Sets a php.ini value."
+msgstr ""
+
+#: Console/Command/TestShell.php:157
+msgid "Choose a custom fixture manager."
+msgstr ""
+
+#: Console/Command/TestShell.php:159
+msgid "More verbose output."
+msgstr ""
+
+#: Console/Command/TestShell.php:250 Console/Command/TestsuiteShell.php:88
+msgid "CakePHP Test Shell"
+msgstr ""
+
+#: Console/Command/TestShell.php:299
+msgid ""
+"No test cases available \n"
+"\n"
+msgstr ""
+
+#: Console/Command/TestShell.php:313
+msgid "What test case would you like to run?"
+msgstr ""
+
+#: Console/Command/TestsuiteShell.php:44
+msgid ""
+"<warning>This shell is for backwards-compatibility only</warning>\n"
+"use the test shell instead"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:73
+msgid "<warning>Dry-run mode enabled!</warning>"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:76
+msgid "<warning>No git repository detected!</warning>"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:91
+msgid "Running %s"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:140
+msgid "Upgrading locations for plugin %s"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:145
+msgid "Upgrading locations for app directory"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:162;618;645;737
+msgid "Moving %s to %s"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:760
+msgid "Updating %s..."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:801
+msgid " * Updating %s"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:805
+msgid "Done updating %s"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:823
+msgid "The plugin to update. Only the specified plugin will be updated."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:827
+msgid ""
+"The extension(s) to search. A pipe delimited list, or a preg_match "
+"compatible subpattern"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:832
+msgid "Use git command for moving files around."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:837
+msgid "Dry run the update, no files will actually be modified."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:844
+msgid ""
+"A tool to help automate upgrading an application or plugin from CakePHP 1.3 "
+"to 2.0. Be sure to have a backup of your application before running these "
+"commands."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:848
+msgid "Run all upgrade commands."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:851
+msgid "Update tests class names to FooTest rather than FooTestCase."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:854
+msgid "Move files and folders to their new homes."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:857
+msgid "Update the i18n translation method calls."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:860
+msgid "Update calls to helpers."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:863
+msgid "Update removed basics functions to PHP native functions."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:866
+msgid "Update removed request access, and replace with $this->request."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:869
+msgid "Update Configure::read() to Configure::read('debug')"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:872
+msgid "Replace Obsolete constants"
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:875
+msgid "Return early on controller redirect calls."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:878
+msgid "Update components to extend Component class."
+msgstr ""
+
+#: Console/Command/UpgradeShell.php:881
+msgid "Replace use of cakeError with exceptions."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:75
+msgid "Baking basic crud methods for "
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:81;121
+msgid "Adding %s methods"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:132
+msgid ""
+"No Controllers were baked, Models need to exist before Controllers can be "
+"baked."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:144
+msgid ""
+"Bake Controller\n"
+"Path: %s"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:153
+msgid "Baking %sController"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:163
+msgid "Would you like to build your controller interactively?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:165
+msgid "Warning: Choosing no will overwrite the %sController."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:172
+msgid "Would you like to use dynamic scaffolding?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:185
+msgid "Would you like to use Session flash messages?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:208
+#: Console/Command/Task/DbConfigTask.php:238
+#: Console/Command/Task/ModelTask.php:274
+#: Console/Command/Task/PluginTask.php:105
+#: Console/Command/Task/ProjectTask.php:196
+#: Console/Command/Task/ViewTask.php:332
+msgid "Look okay?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:237
+msgid "The following controller will be created:"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:239
+msgid ""
+"Controller Name:\n"
+"\t%s"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:246
+msgid "Helpers:"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:247
+msgid "Components:"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:274
+msgid ""
+"Would you like to create some basic class methods \n"
+"(index(), add(), view(), edit())?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:278
+msgid "Would you like to create the basic class methods for admin routing?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:300
+msgid ""
+"You must have a model for this class to build basic methods. Please try "
+"again."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:332
+msgid "Baking controller class for %s..."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:376
+msgid ""
+"Would you like this controller to use other helpers\n"
+"besides HtmlHelper and FormHelper?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:377
+msgid ""
+"Please provide a comma separated list of the other\n"
+"helper names you'd like to use.\n"
+"Example: 'Text, Js, Time'"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:389
+msgid ""
+"Would you like this controller to use other components\n"
+"besides PaginatorComponent?"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:390
+msgid ""
+"Please provide a comma separated list of the component names you'd like to "
+"use.\n"
+"Example: 'Acl, Security, RequestHandler'"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:425
+msgid "Possible Controllers based on your current database:"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:449
+msgid ""
+"Enter a number from the list above,\n"
+"type in the name of another controller, or 'q' to exit"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:451
+#: Console/Command/Task/ModelTask.php:984
+msgid "Exit"
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:456
+msgid ""
+"The Controller name you supplied was empty,\n"
+"or the number you selected was not an option. Please try again."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:478
+msgid ""
+"Bake a controller for a model. Using options you can bake public, admin or "
+"both."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:480
+msgid ""
+"Name of the controller to bake. Can use Plugin.name to bake controllers into "
+"plugins."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:482
+msgid ""
+"Bake a controller with basic crud actions (index, view, add, edit, delete)."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:485
+msgid "Bake a controller with crud actions for one of the Routing.prefixes."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:489
+msgid "Plugin to bake the controller into."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:492
+msgid "The connection the controller's model is on."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:498
+#: Console/Command/Task/FixtureTask.php:94
+#: Console/Command/Task/ModelTask.php:1026
+#: Console/Command/Task/TestTask.php:574 Console/Command/Task/ViewTask.php:444
+msgid "Force overwriting existing files without prompting."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:500
+msgid "Bake all controllers with CRUD methods."
+msgstr ""
+
+#: Console/Command/Task/ControllerTask.php:502
+#: Console/Command/Task/FixtureTask.php:101
+#: Console/Command/Task/ModelTask.php:1028
+#: Console/Command/Task/TestTask.php:576 Console/Command/Task/ViewTask.php:448
+msgid "Omitting all arguments and options will enter into an interactive mode."
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:89
+msgid "Database Configuration:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:98
+msgid "Name:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:101
+msgid ""
+"The name may only contain unaccented latin characters, numbers or underscores"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:104
+msgid "The name must start with an unaccented latin character or an underscore"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:108
+msgid "Datasource:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:110
+msgid "Persistent Connection?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:119
+msgid "Database Host:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:124
+msgid "Port?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:133
+msgid "User:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:139
+msgid "Password:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:142
+msgid "The password you supplied was empty. Use an empty password?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:151
+msgid "Database Name:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:156
+msgid "Table Prefix?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:164
+msgid "Table encoding?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:173
+msgid "Table schema?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:187
+msgid "Do you wish to add another database configuration?"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:210
+msgid "The following database configuration will be created:"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:212
+msgid "Name:         %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:213
+msgid "Datasource:   %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:214
+msgid "Persistent:   %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:215
+msgid "Host:         %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:218
+msgid "Port:         %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:221
+msgid "User:         %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:222
+msgid "Pass:         %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:223
+msgid "Database:     %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:226
+msgid "Table prefix: %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:230
+msgid "Schema:       %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:234
+msgid "Encoding:     %s"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:365
+msgid "Use Database Config"
+msgstr ""
+
+#: Console/Command/Task/DbConfigTask.php:379
+msgid "Bake new database configuration settings."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:123
+msgid ""
+"Current paths: %s\n"
+"What is the path you would like to extract?\n"
+"[Q]uit [D]one"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:130;207
+msgid "Extract Aborted"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:136
+msgid "<warning>No directories selected.</warning> Please choose a directory."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:141;213
+msgid "The directory path you supplied was not found. Please try again."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:175
+msgid "Would you like to extract the messages from the CakePHP core?"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:203
+msgid ""
+"What is the path you would like to output?\n"
+"[Q]uit"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:223
+msgid ""
+"Would you like to merge all domain and category strings into the default.pot "
+"file?"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:233
+msgid "The output directory %s was not found or writable."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:283
+msgid "Extracting..."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:285
+msgid "Paths:"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:289
+msgid "Output Directory: "
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:299
+msgid "Done."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:311
+msgid "CakePHP Language String Extraction:"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:313
+msgid "Directory where your application is located."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:315
+msgid "Comma separated list of paths."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:317
+msgid "Merge all domain and category strings into the default.po file."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:320
+msgid "Full path to output directory."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:322
+msgid "Comma separated list of files."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:326
+msgid ""
+"Ignores all files in plugins if this command is run inside from the same app "
+"directory."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:328
+msgid ""
+"Extracts tokens only from the plugin specified and puts the result in the "
+"plugin's Locale directory."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:332
+msgid ""
+"Ignores validation messages in the $validate property. If this flag is not "
+"set and the command is run from the same app directory, all messages in "
+"model validation rules will be extracted as tokens."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:337
+msgid ""
+"If set to a value, the localization domain to be used for model validation "
+"messages."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:339
+msgid ""
+"Comma separated list of directories to exclude. Any path containing a path "
+"segment with the provided values will be skipped. E.g. test,vendors"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:345
+msgid "Always overwrite existing .pot files."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:347
+msgid "Extract messages from the CakePHP core libs."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:362
+msgid "Processing %s..."
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:655
+msgid ""
+"Error: %s already exists in this location. Overwrite? [Y]es, [N]o, [A]ll"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:662
+msgid "What would you like to name this file?"
+msgstr ""
+
+#: Console/Command/Task/ExtractTask.php:759
+msgid ""
+"Invalid marker content in %s:%s\n"
+"* %s("
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:71
+msgid ""
+"Generate fixtures for use with the test suite. You can use `bake fixture "
+"all` to bake all fixtures."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:73
+msgid ""
+"Name of the fixture to bake. Can use Plugin.name to bake plugin fixtures."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:75
+msgid ""
+"When using generated data, the number of records to include in the "
+"fixture(s)."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:79
+msgid "Which database configuration to use for baking."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:83
+msgid "CamelCased name of the plugin to bake fixtures for."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:86
+msgid "Importing schema for fixtures rather than hardcoding it."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:96
+msgid ""
+"Used with --count and <name>/all commands to pull [n] records from the live "
+"tables, where [n] is either --count or the default of 10."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:160
+msgid ""
+"Bake Fixture\n"
+"Path: %s"
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:184
+msgid "Would you like to import schema for this fixture?"
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:192
+msgid "Would you like to use record importing for this fixture?"
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:198
+msgid "Would you like to build this fixture with data from %s's table?"
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:286
+msgid "Baking test fixture for %s..."
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:419
+msgid ""
+"Please provide a SQL fragment to use as conditions\n"
+"Example: WHERE 1=1"
+msgstr ""
+
+#: Console/Command/Task/FixtureTask.php:423
+msgid "How many records do you want to import?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:128
+msgid "Baking %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:176
+msgid "Make a selection from the choices above"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:193
+msgid ""
+"Bake Model\n"
+"Path: %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:208
+msgid ""
+"The table %s doesn't exist or could not be automatically detected\n"
+"continue anyway?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:234
+msgid ""
+"Would you like to supply validation criteria \n"
+"for the fields in your model?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:240
+msgid ""
+"Would you like to define model associations\n"
+"(hasMany, hasOne, belongsTo, etc.)?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:249
+msgid "The following Model will be created:"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:251
+msgid "Name:       %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:254
+msgid "DB Config:  %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:257
+msgid "DB Table:   %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:260
+msgid "Primary Key: %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:263
+msgid "Validation: %s"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:266
+msgid "Associations:"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:320
+msgid "What is the primaryKey?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:331
+msgid ""
+"A displayField could not be automatically detected\n"
+"would you like to choose one?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:336
+msgid "Choose a field from the options above:"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:411
+msgid ""
+"or enter in a valid regex validation string.\n"
+"Alternatively [s] skip the rest of the fields.\n"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:420
+msgid "Field: <info>%s</info>"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:421
+msgid "Type: <info>%s</info>"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:423
+msgid "Please select one of the following validation options:"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:435
+msgid "%s - Do not do any validation on this field."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:473
+msgid ""
+"You have already chosen that validation rule,\n"
+"please choose again"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:477
+msgid "Please make a valid selection."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:499
+msgid ""
+"Would you like to add another validation rule\n"
+"or skip the rest of the fields?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:521
+msgid "One moment while the associations are detected."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:551
+msgid "None found."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:553
+msgid "Please confirm the following associations:"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:725
+msgid "Would you like to define some additional model associations?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:730
+msgid "What is the association type?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:731
+msgid "Enter a number"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:733
+msgid ""
+"For the following options be very careful to match your setup exactly.\n"
+"Any spelling mistakes will cause errors."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:737
+msgid "What is the alias for this association?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:738
+msgid "What className will %s use?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:760
+msgid "What is the table for this model?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:766
+msgid "A helpful List of possible keys"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:767
+msgid "What is the foreignKey?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:771
+msgid "What is the foreignKey? Specify your own."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:774
+msgid "What is the associationForeignKey?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:775
+msgid "What is the joinTable?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:787
+msgid "Define another association?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:859
+msgid "Baking model class for %s..."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:893
+msgid "Possible Models based on your current database:"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:925
+msgid ""
+"Given your model named '%s',\n"
+"Cake would expect a database table named '%s'"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:926
+msgid "Do you want to use this table?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:929
+msgid "What is the name of the table (without prefix)?"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:961
+msgid "Your database does not have any tables."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:980
+msgid ""
+"Enter a number from the list above,\n"
+"type in the name of another model, or 'q' to exit"
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:989
+msgid ""
+"The model name you supplied was empty,\n"
+"or the number you selected was not an option. Please try again."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:1010
+msgid "Bake models."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:1012
+msgid "Name of the model to bake. Can use Plugin.name to bake plugin models."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:1014
+msgid "Bake all model files with associations and validation."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:1017
+msgid "Plugin to bake the model into."
+msgstr ""
+
+#: Console/Command/Task/ModelTask.php:1023
+msgid "The connection the model table is on."
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:63
+msgid "Plugin: %s already exists, no action taken"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:81
+msgid "Enter the name of the plugin in CamelCase format"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:85
+msgid "An error occurred trying to bake: %s in %s"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:101
+msgid "<info>Plugin Name:</info> %s"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:102
+msgid "<info>Plugin Directory:</info> %s"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:169
+#: Console/Command/Task/ProjectTask.php:207
+msgid "<success>Created:</success> %s in %s"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:211
+msgid "Choose a plugin path from the paths above."
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:229
+msgid ""
+"Create the directory structure, AppModel and AppController classes for a new "
+"plugin. Can create plugins in any of your bootstrapped plugin paths."
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:232
+msgid "CamelCased name of the plugin to create."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:58
+msgid "What is the path to the project you want to bake?"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:68
+msgid ""
+"<warning>A project already exists in this location:</warning> %s Overwrite?"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:80
+msgid " * Random hash key created for 'Security.salt'"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:82
+msgid ""
+"Unable to generate random hash for 'Security.salt', you should change it in "
+"%s"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:87
+msgid " * Random seed created for 'Security.cipherSeed'"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:89
+msgid ""
+"Unable to generate random seed for 'Security.cipherSeed', you should change "
+"it in %s"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:94
+msgid " * Cache prefix set"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:96
+msgid "The cache prefix was <error>NOT</error> set"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:101
+msgid " * app/Console/cake.php path set."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:103
+msgid "Unable to set console path for app/Console."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:109
+msgid ""
+"<info>CakePHP is on your `include_path`. CAKE_CORE_INCLUDE_PATH will be set, "
+"but commented out.</info>"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:111
+msgid ""
+"<warning>CakePHP is not on your `include_path`, CAKE_CORE_INCLUDE_PATH will "
+"be hard coded.</warning>"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:112
+msgid "You can fix this by adding CakePHP to your `include_path`."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:117;118
+msgid " * CAKE_CORE_INCLUDE_PATH set to %s in %s"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:120
+msgid "Unable to set CAKE_CORE_INCLUDE_PATH, you should change it in %s"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:124
+msgid ""
+"   * <warning>Remember to check these values after moving to production "
+"server</warning>"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:129
+msgid "Could not set permissions on %s"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:134
+msgid "<success>Project baked successfully!</success>"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:136
+msgid "Project baked but with <warning>some issues.</warning>."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:173
+msgid "What is the path to the directory layout you wish to copy?"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:178
+msgid "The directory path you supplied was empty. Please try again."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:182
+msgid "Directory path does not exist please choose another:"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:192
+msgid "<info>Skel Directory</info>: "
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:193
+msgid "<info>Will be copied to</info>: "
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:210
+msgid "<error>Could not create</error> '%s' properly."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:224
+msgid "<error>Bake Aborted.</error>"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:392
+msgid "You have more than one routing prefix configured"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:401
+msgid "Please choose a prefix to bake with."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:406;416
+msgid "You need to enable %s in %s to use prefix routing."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:409
+msgid "What would you like the prefix route to be?"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:410
+msgid "Example: %s"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:412
+msgid "Enter a routing prefix:"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:415
+msgid "<error>Unable to write to</error> %s."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:435
+msgid "Generate a new CakePHP project skeleton."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:437
+msgid ""
+"Application directory to make, if it starts with \"/\" the path is absolute."
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:440
+msgid ""
+"Create empty files in each of the directories. Good if you are using git"
+msgstr ""
+
+#: Console/Command/Task/ProjectTask.php:446
+msgid ""
+"The directory layout to use for the new application skeleton. Defaults to "
+"cake/Console/Templates/skel of CakePHP used to create the project."
+msgstr ""
+
+#: Console/Command/Task/TemplateTask.php:176
+msgid "You have more than one set of templates installed."
+msgstr ""
+
+#: Console/Command/Task/TemplateTask.php:177
+msgid "Please choose the template set you wish to use:"
+msgstr ""
+
+#: Console/Command/Task/TemplateTask.php:187
+msgid "Which bake theme would you like to use?"
+msgstr ""
+
+#: Console/Command/Task/TemplateTask.php:213
+msgid "Could not find template for %s"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:111
+msgid "Bake Tests"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:118
+msgid "Incorrect type provided. Please choose one of %s"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:144
+msgid "Bake is detecting possible fixtures..."
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:162
+msgid "Baking test case for %s %s ..."
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:188
+msgid "Select an object type:"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:198
+msgid "Enter the type of object to bake a test for or (q)uit"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:222
+msgid "Choose a %s class"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:229
+msgid ""
+"Choose an existing class, or enter the name of a class that does not exist"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:453
+msgid "Bake could not detect fixtures, would you like to add some?"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:456
+msgid ""
+"Please provide a comma separated list of the fixtures names you'd like to "
+"use.\n"
+"Example: 'app.comment, app.post, plugin.forums.post'"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:554
+msgid "Bake test case skeletons for classes."
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:556
+msgid ""
+"Type of class to bake, can be any of the following: controller, model, "
+"helper, component or behavior."
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:565
+msgid "An existing class to bake tests for."
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:571
+msgid "CamelCased name of the plugin to bake tests for."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:209
+msgid ""
+"Would you like bake to build your views interactively?\n"
+"Warning: Choosing no will overwrite %s views if they exist."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:216
+msgid ""
+"Would you like to create some CRUD views\n"
+"(index, add, view, edit) for this controller?\n"
+"NOTE: Before doing so, you'll need to create your controller\n"
+"and model classes (including associated models)."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:219
+msgid "Would you like to create the views for admin routing?"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:238
+msgid "View Scaffolding Complete.\n"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:255
+msgid "Controller not found"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:267
+msgid ""
+"The file '%s' could not be found.\n"
+"In order to bake a view, you'll need to first create the controller."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:319
+msgid "Action Name? (use lowercase_underscored function name)"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:321
+msgid "The action name you supplied was empty. Please try again."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:326
+msgid "The following view will be created:"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:328
+msgid "Controller Name: %s"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:329
+msgid "Action Name:     %s"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:330
+msgid "Path:            %s"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:337
+msgid "Bake Aborted."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:354
+msgid "Baking `%s` view file..."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:423
+msgid "Bake views for a controller, using built-in or custom templates."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:425
+msgid ""
+"Name of the controller views to bake. Can be Plugin.name as a shortcut for "
+"plugin baking."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:427
+msgid ""
+"Will bake a single action's file. core templates are (index, add, edit, view)"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:429
+msgid ""
+"Will bake the template in <action> but create the filename after <alias>."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:432
+msgid "Plugin to bake the view into."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:434
+msgid "Set to only bake views for a prefix in Routing.prefixes"
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:441
+msgid "The connection the connected model is on."
+msgstr ""
+
+#: Console/Command/Task/ViewTask.php:446
+msgid ""
+"Bake all CRUD action views for all controllers. Requires models and "
+"controllers to exist."
+msgstr ""

--- a/Locale/fra/LC_MESSAGES/cake_dev.po
+++ b/Locale/fra/LC_MESSAGES/cake_dev.po
@@ -1,0 +1,1270 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2015-01-19 07:43+0000\n"
+"PO-Revision-Date: 2015-01-19 09:46+0100\n"
+"Last-Translator: cake17 <cake17@cake-websites.com>\n"
+"Language-Team: Cakephp-fr.org <contact@cakephp-fr.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 1.7.3\n"
+"Language: fr\n"
+
+#: View/Layouts/default.ctp:17 View/Layouts/error.ctp:17
+msgid "CakePHP: the rapid development php framework"
+msgstr "CakePHP: le framework PHP de développement rapide"
+
+#: View/Layouts/default.ctp:18
+msgid "CakePHP %s"
+msgstr ""
+
+#: View/Pages/home.ctp:14
+msgid "Release Notes for CakePHP %s."
+msgstr "Notes de Versions pour CakePHP %s."
+
+#: View/Pages/home.ctp:16
+msgid "Read the changelog"
+msgstr "Lire le changelog"
+
+#: View/Pages/home.ctp:25
+msgid "URL rewriting is not properly configured on your server."
+msgstr "Le rewriting URL n'est pas configuré correctement sur votre serveur."
+
+#: View/Pages/home.ctp:34
+msgid "Your version of PHP is 5.2.8 or higher."
+msgstr "Votre version de PHP est la version 5.2.8 ou supérieur."
+
+#: View/Pages/home.ctp:38
+msgid ""
+"Your version of PHP is too low. You need PHP 5.2.8 or higher to use CakePHP."
+msgstr ""
+"Votre version de PHP est trop ancienne. Vous devez avoir PHP 5.2.8 ou "
+"supérieur pour utiliser CakePHP."
+
+#: View/Pages/home.ctp:47
+msgid "Your tmp directory is writable."
+msgstr "Votre répertoire tmp est en écriture."
+
+#: View/Pages/home.ctp:51
+msgid "Your tmp directory is NOT writable."
+msgstr "Votre répertoire tmp N'est PAS en écriture."
+
+#: View/Pages/home.ctp:61
+msgid "The %s is being used for core caching. To change the config edit %s"
+msgstr ""
+"%s est utilisé pour la mise en cache du coeur. Pour changer la config, "
+"modifiez %s"
+
+#: View/Pages/home.ctp:65
+msgid "Your cache is NOT working. Please check the settings in %s"
+msgstr ""
+"Votre cache NE fonctionne PAS. Merci de vérifier les configurations dans %s"
+
+#: View/Pages/home.ctp:75
+msgid "Your database configuration file is present."
+msgstr "Votre fichier de configuration de base de données est présent."
+
+#: View/Pages/home.ctp:80
+msgid "Your database configuration file is NOT present."
+msgstr "Votre fichier de configuration de base de données N'est PAS présent."
+
+#: View/Pages/home.ctp:82
+msgid "Rename %s to %s"
+msgstr "Renommez %s en %s"
+
+#: View/Pages/home.ctp:107
+msgid "CakePHP is able to connect to the database."
+msgstr "CakePHP peut se connecter à la base de données."
+
+#: View/Pages/home.ctp:111
+msgid "CakePHP is NOT able to connect to the database."
+msgstr "CakePHP NE peut PAS se connecter à la base de données."
+
+#: View/Pages/home.ctp:124
+msgid "PCRE has not been compiled with Unicode support."
+msgstr "PCRE n'a pas été compilé avec le support Unicode."
+
+#: View/Pages/home.ctp:126
+msgid ""
+"Recompile PCRE with Unicode support by adding <code>--enable-unicode-"
+"properties</code> when configuring"
+msgstr ""
+"Recompilez PCRE avec le support Unicode ne ajoutant <code>--enable-unicode-"
+"properties</code> pendant la configuration"
+
+#: View/Pages/home.ctp:135
+msgid "DebugKit plugin is present"
+msgstr "Le plugin DebugKit est présent"
+
+#: View/Pages/home.ctp:139
+msgid ""
+"DebugKit is not installed. It will help you inspect and debug different "
+"aspects of your application."
+msgstr ""
+"DebugKit n'est pas installé. Il vous aidera à inspecter et débugger "
+"différents aspects de votre application."
+
+#: View/Pages/home.ctp:141
+msgid "You can install it from %s"
+msgstr "Vous pouvez l'installer à partir de %s"
+
+#: View/Pages/home.ctp:147
+msgid "Editing this Page"
+msgstr "Modification de cette Page"
+
+#: View/Pages/home.ctp:150
+msgid ""
+"To change the content of this page, edit: %s.<br />\n"
+"To change its layout, edit: %s.<br />\n"
+"You can also add some CSS styles for your pages at: %s."
+msgstr ""
+"Pour changer le contenu de cette page, modifiez: %s.<br />\n"
+"Pour changer son layout, modifiez: %s.<br />\n"
+"Vous pouvez aussi ajouter des styles CSS pour vos pages dans : %s."
+
+#: View/Pages/home.ctp:157
+msgid "Getting Started"
+msgstr "Pour commencer"
+
+#: View/Pages/home.ctp:161
+msgid "New"
+msgstr "Nouveau"
+
+#: View/Pages/home.ctp:161
+msgid "CakePHP 2.0 Docs"
+msgstr "Docs de CakePHP 2.0"
+
+#: View/Pages/home.ctp:170
+msgid "The 15 min Blog Tutorial"
+msgstr "Tutoriel de Blog de 15 min"
+
+#: View/Pages/home.ctp:177
+msgid "Official Plugins"
+msgstr "Plugins officiels"
+
+#: View/Pages/home.ctp:182
+msgid ""
+"provides a debugging toolbar and enhanced debugging tools for CakePHP "
+"applications."
+msgstr "fournit une barre d'outils de debug pour les applications CakePHP."
+
+#: View/Pages/home.ctp:186
+msgid ""
+"contains various localized validation classes and translations for specific "
+"countries"
+msgstr ""
+"contient des classes de validation et des traductions pour certains pays"
+
+#: View/Pages/home.ctp:191
+msgid "More about CakePHP"
+msgstr "En savoir plus sur CakePHP"
+
+#: View/Pages/home.ctp:193
+msgid ""
+"CakePHP is a rapid development framework for PHP which uses commonly known "
+"design patterns like Active Record, Association Data Mapping, Front "
+"Controller and MVC."
+msgstr ""
+"CakePHP est une framework de développement rapide pour PHP qui utilise "
+"habituellement des patrons de conception connus comme Active Record, "
+"Association Data Mapping, Front Controller et MVC."
+
+#: View/Pages/home.ctp:196
+msgid ""
+"Our primary goal is to provide a structured framework that enables PHP users "
+"at all levels to rapidly develop robust web applications, without any loss "
+"to flexibility."
+msgstr ""
+"Notre but principal est de fournir un framework structuré qui permette aux "
+"utilisateurs de PHP de tous niveaux de créer rapidement des applications web "
+"robustes, sans aucune perte de flexibilité."
+
+#: View/Pages/home.ctp:201
+msgid "The Rapid Development Framework"
+msgstr "Le Framework de Développement Rapide"
+
+#: View/Pages/home.ctp:202
+msgid "CakePHP Documentation"
+msgstr "Documentation de CakePHP"
+
+#: View/Pages/home.ctp:203
+msgid "Your Rapid Development Cookbook"
+msgstr "Votre Cookbook de Développement Rapide"
+
+#: View/Pages/home.ctp:204
+msgid "CakePHP API"
+msgstr "API de CakePHP"
+
+#: View/Pages/home.ctp:205
+msgid "Quick API Reference"
+msgstr "Référence d'API Rapide"
+
+#: View/Pages/home.ctp:206
+msgid "The Bakery"
+msgstr "La Bakery"
+
+#: View/Pages/home.ctp:207
+msgid "Everything CakePHP"
+msgstr "Tout sur CakePHP"
+
+#: View/Pages/home.ctp:208
+msgid "CakePHP Plugins"
+msgstr "Plugins de CakePHP"
+
+#: View/Pages/home.ctp:209
+msgid "A comprehensive list of all CakePHP plugins created by the community"
+msgstr ""
+"Une liste compréhensible de tous les plugins de CakePHP créés par la "
+"communauté"
+
+#: View/Pages/home.ctp:210
+msgid "CakePHP Community Center"
+msgstr "Centre de la Communauté de CakePHP"
+
+#: View/Pages/home.ctp:211
+msgid "Everything related to the CakePHP community in one place"
+msgstr "Tout ce qui est lié à la communauté de CakePHP en un seul endroit"
+
+#: View/Pages/home.ctp:212
+msgid "CakePHP Google Group"
+msgstr "Groupe Google de CakePHP"
+
+#: View/Pages/home.ctp:213
+msgid "Community mailing list"
+msgstr "Mailing Liste de la Communauté"
+
+#: View/Pages/home.ctp:215
+msgid "Live chat about CakePHP"
+msgstr "Chat en live sur CakePHP"
+
+#: View/Pages/home.ctp:216
+msgid "CakePHP Code"
+msgstr "Code de CakePHP"
+
+#: View/Pages/home.ctp:217
+msgid "Find the CakePHP code on GitHub and contribute to the framework"
+msgstr "Consulte le code de CakePHP sur GitHub et contribue au framework"
+
+#: View/Pages/home.ctp:218;219
+msgid "CakePHP Issues"
+msgstr "Problèmes de CakePHP"
+
+#: View/Pages/home.ctp:220;221
+msgid "CakePHP Roadmaps"
+msgstr "Roadmaps de CakePHP"
+
+#: View/Pages/home.ctp:222
+msgid "Training"
+msgstr "Entraînement"
+
+#: View/Pages/home.ctp:223
+msgid "Join a live session and get skilled with the framework"
+msgstr "Rejoins une session en direct et améliore-toi avec le framework"
+
+#: View/Pages/home.ctp:224
+msgid "CakeFest"
+msgstr ""
+
+#: View/Pages/home.ctp:225
+msgid "Don't miss our annual CakePHP conference"
+msgstr "Ne ratez pas notre conférence CakePHP annuelle"
+
+#: View/Pages/home.ctp:226
+msgid "Cake Software Foundation"
+msgstr ""
+
+#: View/Pages/home.ctp:227
+msgid "Promoting development related to CakePHP"
+msgstr "Faire la promotion du développement lié à CakePHP"
+
+#: webroot/test.php:103
+msgid "Debug setting does not allow access to this url."
+msgstr "La Configuration du debug ne permet pas l'accès  à cette url."
+
+#: Cache/Cache.php:173
+msgid "Cache engine %s is not available."
+msgstr "Le moteur de cache %s n'est pas disponible."
+
+#: Cache/Cache.php:177
+msgid "Cache engines must use %s as a base class."
+msgstr ""
+
+#: Cache/Cache.php:181
+msgid ""
+"Cache engine \"%s\" is not properly configured. Ensure required extensions "
+"are installed, and credentials/permissions are correct"
+msgstr ""
+
+#: Cache/Cache.php:321
+msgid "%s cache was unable to write '%s' to %s cache"
+msgstr ""
+
+#: Cache/Cache.php:543
+msgid "Invalid cache group %s"
+msgstr ""
+
+#: Cache/Engine/FileEngine.php:313
+msgid "Files cannot be atomically decremented."
+msgstr ""
+
+#: Cache/Engine/FileEngine.php:325
+msgid "Files cannot be atomically incremented."
+msgstr ""
+
+#: Cache/Engine/FileEngine.php:362
+msgid "Could not apply permission mask \"%s\" on cache file \"%s\""
+msgstr ""
+
+#: Cache/Engine/FileEngine.php:385
+msgid "%s is not writable"
+msgstr ""
+
+#: Cache/Engine/MemcacheEngine.php:166;183
+msgid "Method %s not implemented for compressed cache in %s"
+msgstr ""
+
+#: Cache/Engine/MemcachedEngine.php:133
+msgid "Memcached extension is not build with SASL support"
+msgstr ""
+
+#: Cache/Engine/MemcachedEngine.php:160
+msgid "%s is not a valid serializer engine for Memcached"
+msgstr ""
+
+#: Cache/Engine/MemcachedEngine.php:166
+msgid "Memcached extension is not compiled with %s support"
+msgstr ""
+
+#: Configure/IniReader.php:101 Configure/PhpReader.php:64
+msgid "Cannot load configuration files with ../ in them."
+msgstr ""
+
+#: Configure/IniReader.php:106 Configure/PhpReader.php:69
+msgid "Could not load configuration file: %s"
+msgstr ""
+
+#: Configure/PhpReader.php:74
+msgid "No variable %s found in %s"
+msgstr ""
+
+#: Console/Command/TestShell.php:175
+msgid ""
+"Please install PHPUnit framework v3.7 <info>(http://www.phpunit.de)</info>"
+msgstr ""
+
+#: Console/Command/TestShell.php:371
+msgid "Test case %s cannot be run via this shell"
+msgstr ""
+
+#: Console/Command/TestShell.php:384;401
+msgid "Test case %s not found"
+msgstr ""
+
+#: Console/Command/Task/PluginTask.php:187
+msgid "%s modified"
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:322
+msgid "Invalid object type."
+msgstr ""
+
+#: Console/Command/Task/TestTask.php:341
+msgid "Invalid type name"
+msgstr ""
+
+#: Controller/Component/AclComponent.php:67
+msgid "Could not find %s."
+msgstr ""
+
+#: Controller/Component/AclComponent.php:91
+msgid "AclComponent adapters must implement AclInterface"
+msgstr ""
+
+#: Controller/Component/AclComponent.php:162;176
+msgid "%s is deprecated, use %s instead"
+msgstr ""
+
+#: Controller/Component/AuthComponent.php:496
+msgid "Authorization adapter \"%s\" was not found."
+msgstr ""
+
+#: Controller/Component/AuthComponent.php:499
+msgid "Authorization objects must implement an %s method."
+msgstr ""
+
+#: Controller/Component/AuthComponent.php:796
+msgid "Authentication adapter \"%s\" was not found."
+msgstr ""
+
+#: Controller/Component/AuthComponent.php:799
+msgid "Authentication objects must implement an %s method."
+msgstr ""
+
+#: Controller/Component/CookieComponent.php:387
+msgid "You must use cipher, rijndael or aes for cookie encryption type"
+msgstr ""
+
+#: Controller/Component/RequestHandlerComponent.php:757
+msgid "You must give a handler callback."
+msgstr ""
+
+#: Controller/Component/SecurityComponent.php:335;620
+msgid "The request has been black-holed"
+msgstr ""
+
+#: Controller/Component/Acl/PhpAcl.php:104
+msgid "\"roles\" section not found in configuration."
+msgstr ""
+
+#: Controller/Component/Acl/PhpAcl.php:108
+msgid "Neither \"allow\" nor \"deny\" rules were provided in configuration."
+msgstr ""
+
+#: Controller/Component/Acl/PhpAcl.php:528
+msgid "cycle detected when inheriting %s from %s. Path: %s"
+msgstr ""
+
+#: Controller/Component/Auth/BaseAuthenticate.php:172
+msgid "Password hasher class \"%s\" was not found."
+msgstr ""
+
+#: Controller/Component/Auth/BaseAuthenticate.php:175
+msgid "Password hasher must extend AbstractPasswordHasher class."
+msgstr ""
+
+#: Controller/Component/Auth/BaseAuthorize.php:95
+msgid "$controller needs to be an instance of Controller"
+msgstr ""
+
+#: Controller/Component/Auth/ControllerAuthorize.php:49
+msgid "$controller does not implement an %s method."
+msgstr ""
+
+#: Controller/Component/Auth/CrudAuthorize.php:83
+msgid ""
+"CrudAuthorize::authorize() - Attempted access of un-mapped action \"%1$s\" "
+"in controller \"%2$s\""
+msgstr ""
+
+#: Core/Configure.php:73
+msgid ""
+"Can't find application core file. Please create %s, and make sure it is "
+"readable by PHP."
+msgstr ""
+
+#: Core/Configure.php:93
+msgid ""
+"Can't find application bootstrap file. Please create %s, and make sure it is "
+"readable by PHP."
+msgstr ""
+
+#: Core/Configure.php:341
+msgid "There is no \"%s\" adapter."
+msgstr ""
+
+#: Core/Configure.php:344
+msgid "The \"%s\" adapter, does not have a %s method."
+msgstr ""
+
+#: Event/CakeEventManager.php:102
+msgid "The eventKey variable is required"
+msgstr ""
+
+#: I18n/I18n.php:229
+msgid "You cannot use \"\" as a domain."
+msgstr ""
+
+#: I18n/I18n.php:269
+msgid ""
+"Missing plural form translation for \"%s\" in \"%s\" domain, \"%s\" locale.  "
+"Check your po file for correct plurals and valid Plural-Forms header."
+msgstr ""
+
+#: Log/CakeLog.php:191
+msgid "Invalid key name"
+msgstr ""
+
+#: Log/CakeLog.php:194
+msgid "Missing logger class name"
+msgstr ""
+
+#: Log/CakeLog.php:315;333;352
+msgid "Stream %s not found"
+msgstr ""
+
+#: Log/LogEngineCollection.php:44
+msgid "logger class %s does not implement a %s method."
+msgstr ""
+
+#: Log/LogEngineCollection.php:69
+msgid "Could not load class %s"
+msgstr ""
+
+#: Log/Engine/FileLog.php:150
+msgid "Could not apply permission mask \"%s\" on log file \"%s\""
+msgstr ""
+
+#: Model/AclNode.php:178
+msgid "AclNode::node() - Couldn't find %s node identified by \"%s\""
+msgstr ""
+
+#: Model/BehaviorCollection.php:226
+msgid "%s - Method %s not found in any attached behavior"
+msgstr ""
+
+#: Model/CakeSchema.php:613
+msgid ""
+"Schema generation error: invalid column type %s for %s.%s does not exist in "
+"DBO"
+msgstr ""
+
+#: Model/Model.php:1413
+msgid ""
+"(Model::getColumnTypes) Unable to build model field data. If you are using a "
+"model without a database table, try implementing schema()"
+msgstr ""
+
+#: Model/Model.php:3725
+msgid ""
+"Invalid join model settings in %s. The association parameter has the wrong "
+"type, expecting a string or array, but was passed type: %s"
+msgstr ""
+
+#: Model/Permission.php:84
+msgid ""
+"%s - Failed ARO node lookup in permissions check. Node references:\n"
+"Aro: %s\n"
+"Aco: %s"
+msgstr ""
+
+#: Model/Permission.php:95
+msgid ""
+"%s - Failed ACO node lookup in permissions check. Node references:\n"
+"Aro: %s\n"
+"Aco: %s"
+msgstr ""
+
+#: Model/Permission.php:106
+msgid "ACO permissions key %s does not exist in %s"
+msgstr ""
+
+#: Model/Permission.php:177
+msgid "%s - Invalid node"
+msgstr ""
+
+#: Model/Permission.php:195
+msgid "Invalid permission key \"%s\""
+msgstr ""
+
+#: Model/Behavior/AclBehavior.php:66
+msgid "Callback %s not defined in %s"
+msgstr ""
+
+#: Model/Behavior/AclBehavior.php:83
+msgid ""
+"AclBehavior is setup with more then one type, please specify type parameter "
+"for node()"
+msgstr ""
+
+#: Model/Behavior/ContainableBehavior.php:342
+msgid "Model \"%s\" is not associated with model \"%s\""
+msgstr ""
+
+#: Model/Behavior/TranslateBehavior.php:71
+msgid "Datasource %s for TranslateBehavior of model %s is not connected"
+msgstr ""
+
+#: Model/Behavior/TranslateBehavior.php:606
+msgid "You cannot bind a translation named \"name\"."
+msgstr ""
+
+#: Model/Behavior/TranslateBehavior.php:628
+msgid "Association %s is already bound to model %s"
+msgstr ""
+
+#: Model/Datasource/CakeSession.php:516
+msgid "Unable to configure the session, setting %s failed."
+msgstr ""
+
+#: Model/Datasource/CakeSession.php:575
+msgid "Could not load %s to handle the session."
+msgstr ""
+
+#: Model/Datasource/CakeSession.php:581
+msgid ""
+"Chosen SessionHandler does not implement CakeSessionHandlerInterface it "
+"cannot be used with an engine key."
+msgstr ""
+
+#: Model/Datasource/DboSource.php:255
+msgid "Selected driver is not enabled"
+msgstr ""
+
+#: Model/Datasource/DboSource.php:1263
+msgid "Error in Model %s"
+msgstr ""
+
+#: Model/Datasource/DboSource.php:3217
+msgid "Invalid schema object"
+msgstr ""
+
+#: Model/Datasource/DboSource.php:3327
+#: Model/Datasource/Database/Sqlite.php:407
+msgid "Column name or type not defined in schema"
+msgstr ""
+
+#: Model/Datasource/DboSource.php:3332
+#: Model/Datasource/Database/Sqlite.php:412
+msgid "Column type %s does not exist"
+msgstr ""
+
+#: Model/Datasource/Database/Mysql.php:342
+#: Model/Datasource/Database/Sqlserver.php:227
+msgid "Could not describe table for %s"
+msgstr ""
+
+#: Model/Validator/CakeValidationRule.php:281
+msgid "Could not find validation handler %s for %s"
+msgstr ""
+
+#: Network/CakeRequest.php:449
+msgid "Method %s does not exist"
+msgstr ""
+
+#: Network/CakeResponse.php:632
+msgid "Unknown status code"
+msgstr ""
+
+#: Network/CakeResponse.php:676
+msgid "Invalid status code"
+msgstr ""
+
+#: Network/CakeResponse.php:1340
+msgid "The requested file contains `..` and will not be read."
+msgstr ""
+
+#: Network/CakeResponse.php:1353
+msgid "The requested file %s was not found or not readable"
+msgstr ""
+
+#: Network/CakeSocket.php:301
+msgid "Connection timed out"
+msgstr ""
+
+#: Network/CakeSocket.php:368
+msgid "Invalid encryption scheme chosen"
+msgstr ""
+
+#: Network/CakeSocket.php:382
+msgid "Unable to perform enableCrypto operation on CakeSocket"
+msgstr ""
+
+#: Network/Email/CakeEmail.php:375
+msgid "From requires only 1 email address."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:391
+msgid "Sender requires only 1 email address."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:407
+msgid "Reply-To requires only 1 email address."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:423
+msgid "Disposition-Notification-To requires only 1 email address."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:439
+msgid "Return-Path requires only 1 email address."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:614
+msgid "Invalid email: \"%s\""
+msgstr ""
+
+#: Network/Email/CakeEmail.php:692;707
+msgid "$headers should be an array."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:919
+msgid "Format not available."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:954
+msgid "Class \"%s\" not found."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:956
+msgid "The \"%s\" does not have a %s method."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:977
+msgid ""
+"Invalid format for Message-ID. The text should be something like "
+"\"<uuid@server.com>\""
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1056
+msgid "No file or data specified."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1059
+msgid "No filename specified."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1066
+msgid "File not found: \"%s\""
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1149
+msgid "From is not specified."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1152
+msgid "You need to specify at least one destination for to, cc or bcc."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1227
+msgid "%s not found."
+msgstr ""
+
+#: Network/Email/CakeEmail.php:1231
+msgid "Unknown email configuration \"%s\"."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:155
+msgid "Unable to connect to SMTP server."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:176
+msgid ""
+"SMTP server did not accept the connection or trying to connect to non TLS "
+"SMTP server using TLS."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:181
+msgid "SMTP server did not accept the connection."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:199
+msgid "SMTP server did not accept the username."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:204
+msgid "SMTP server did not accept the password."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:207
+msgid ""
+"SMTP authentication method not allowed, check if SMTP server requires TLS."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:209
+msgid ""
+"AUTH command not recognized or not implemented, SMTP server may not require "
+"authentication."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:360
+msgid "SMTP timeout."
+msgstr ""
+
+#: Network/Email/SmtpTransport.php:373
+msgid "SMTP Error: %s"
+msgstr ""
+
+#: Network/Http/HttpResponse.php:21
+msgid ""
+"HttpResponse is deprecated due to naming conflicts. Use HttpSocketResponse "
+"instead."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:244
+msgid "Invalid resource."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:410
+msgid "Class %s not found."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:635
+msgid "Unknown authentication method."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:638
+msgid "The %s does not support authentication."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:664
+msgid "Unknown authentication method for proxy."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:667
+msgid "The %s does not support proxy authentication."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:918
+msgid ""
+"HttpSocket::_buildRequestLine - Passed an invalid request line string. "
+"Activate quirks mode to do this."
+msgstr ""
+
+#: Network/Http/HttpSocket.php:936
+msgid ""
+"HttpSocket::_buildRequestLine - The \"*\" asterisk character is only allowed "
+"for the following methods: %s. Activate quirks mode to work outside of "
+"HTTP/1.1 specs."
+msgstr ""
+
+#: Network/Http/HttpSocketResponse.php:151
+msgid "Invalid response."
+msgstr ""
+
+#: Network/Http/HttpSocketResponse.php:155
+msgid "Invalid HTTP response."
+msgstr ""
+
+#: Routing/Router.php:233
+msgid "Route class not found, or route class is not a subclass of CakeRoute"
+msgstr ""
+
+#: Utility/CakeNumber.php:163
+msgid "No unit type."
+msgstr ""
+
+#: Utility/ClassRegistry.php:117
+msgid ""
+"(ClassRegistry::init() Attempted to create instance of a class with a "
+"numeric name"
+msgstr ""
+
+#: Utility/ClassRegistry.php:149
+msgid "Cannot create instance of %s, as it is abstract or is an interface"
+msgstr ""
+
+#: Utility/Debugger.php:630
+msgid "Invalid Debugger output format."
+msgstr ""
+
+#: Utility/Debugger.php:846
+msgid ""
+"Please change the value of %s in %s to a salt value specific to your "
+"application."
+msgstr ""
+
+#: Utility/Debugger.php:850
+msgid ""
+"Please change the value of %s in %s to a numeric (digits only) seed value "
+"specific to your application."
+msgstr ""
+
+#: Utility/Folder.php:409;432
+msgid "%s changed to %s"
+msgstr ""
+
+#: Utility/Folder.php:413;434
+msgid "%s NOT changed to %s"
+msgstr ""
+
+#: Utility/Folder.php:537
+msgid "%s is a file"
+msgstr ""
+
+#: Utility/Folder.php:548;732
+msgid "%s created"
+msgstr ""
+
+#: Utility/Folder.php:552
+msgid "%s NOT created"
+msgstr ""
+
+#: Utility/Folder.php:624;632;644
+msgid "%s removed"
+msgstr ""
+
+#: Utility/Folder.php:626;634;646
+msgid "%s NOT removed"
+msgstr ""
+
+#: Utility/Folder.php:690
+msgid "%s not found"
+msgstr ""
+
+#: Utility/Folder.php:699
+msgid "%s not writable"
+msgstr ""
+
+#: Utility/Folder.php:715
+msgid "%s copied to %s"
+msgstr ""
+
+#: Utility/Folder.php:717
+msgid "%s NOT copied to %s"
+msgstr ""
+
+#: Utility/Folder.php:736
+msgid "%s not created"
+msgstr ""
+
+#: Utility/Hash.php:53
+msgid "Invalid Parameter %s, should be dot separated path or array."
+msgstr ""
+
+#: Utility/Hash.php:414
+msgid "Hash::combine() needs an equal number of keys + values."
+msgstr ""
+
+#: Utility/Hash.php:1081
+msgid "Invalid data array to nest."
+msgstr ""
+
+#: Utility/ObjectCollection.php:124
+msgid "Cannot use modParams with indexes that do not exist."
+msgstr ""
+
+#: Utility/Security.php:159
+msgid "Invalid value, cost must be between %s and %s"
+msgstr ""
+
+#: Utility/Security.php:186;219
+msgid "You cannot use an empty key for %s"
+msgstr ""
+
+#: Utility/Security.php:223
+msgid ""
+"You must specify the operation for Security::rijndael(), either encrypt or "
+"decrypt"
+msgstr ""
+
+#: Utility/Security.php:227
+msgid "You must use a key larger than 32 bytes for Security::rijndael()"
+msgstr ""
+
+#: Utility/Security.php:286
+msgid ""
+"Invalid salt: %s for %s Please visit http://www.php.net/crypt and read the "
+"appropriate section for building %s salts."
+msgstr ""
+
+#: Utility/Security.php:339
+msgid "Invalid key for %s, key must be at least 256 bits (32 bytes) long."
+msgstr ""
+
+#: Utility/Security.php:355
+msgid "The data to decrypt cannot be empty."
+msgstr ""
+
+#: Utility/Validation.php:272
+msgid "You must define the $operator parameter for %s"
+msgstr ""
+
+#: Utility/Validation.php:290
+msgid "You must define a regular expression for %s"
+msgstr ""
+
+#: Utility/Validation.php:869
+msgid "Could not find %s class, unable to complete validation."
+msgstr ""
+
+#: Utility/Validation.php:873
+msgid "Method %s does not exist on %s unable to complete validation."
+msgstr ""
+
+#: Utility/Validation.php:967
+msgid "Can not determine the mimetype."
+msgstr ""
+
+#: Utility/Xml.php:108;112;117
+msgid "XML cannot be read."
+msgstr ""
+
+#: Utility/Xml.php:115;194
+msgid "Invalid input."
+msgstr ""
+
+#: Utility/Xml.php:149
+msgid "Xml cannot be read."
+msgstr ""
+
+#: Utility/Xml.php:198
+msgid "The key of input must be alphanumeric"
+msgstr ""
+
+#: Utility/Xml.php:275;288
+msgid "Invalid array"
+msgstr ""
+
+#: Utility/Xml.php:339
+msgid "The input is not instance of SimpleXMLElement, DOMDocument or DOMNode."
+msgstr ""
+
+#: View/Helper.php:192
+msgid "Method %1$s::%2$s does not exist"
+msgstr ""
+
+#: View/View.php:425
+msgid "Element Not Found: %s"
+msgstr ""
+
+#: View/View.php:731
+msgid "You cannot extend an element which does not exist (%s)."
+msgstr ""
+
+#: View/View.php:747
+msgid "You cannot have views extend themselves."
+msgstr ""
+
+#: View/View.php:750
+msgid "You cannot have views extend in a loop."
+msgstr ""
+
+#: View/View.php:942
+msgid "The \"%s\" block was left open. Blocks are not allowed to cross files."
+msgstr ""
+
+#: View/Elements/sql_dump.ctp:81
+msgid "Encountered unexpected %s. Cannot generate SQL log."
+msgstr ""
+
+#: View/Errors/fatal_error.ctp:18
+msgid "Fatal Error"
+msgstr ""
+
+#: View/Errors/fatal_error.ctp:20 View/Errors/missing_action.ctp:19;23
+#: View/Errors/missing_behavior.ctp:21;25
+#: View/Errors/missing_component.ctp:21;25
+#: View/Errors/missing_connection.ctp:19;30
+#: View/Errors/missing_controller.ctp:21;25
+#: View/Errors/missing_database.ctp:19;23
+#: View/Errors/missing_datasource.ctp:21
+#: View/Errors/missing_datasource_config.ctp:19
+#: View/Errors/missing_helper.ctp:21;25 View/Errors/missing_layout.ctp:19
+#: View/Errors/missing_plugin.ctp:19;23 View/Errors/missing_table.ctp:19
+#: View/Errors/missing_view.ctp:19 View/Errors/pdo_error.ctp:19
+#: View/Errors/private_action.ctp:19 View/Errors/scaffold_error.ctp:19
+msgid "Error"
+msgstr ""
+
+#: View/Errors/fatal_error.ctp:24
+msgid "File"
+msgstr ""
+
+#: View/Errors/fatal_error.ctp:28
+msgid "Line"
+msgstr ""
+
+#: View/Errors/fatal_error.ctp:32 View/Errors/missing_action.ctp:38
+#: View/Errors/missing_behavior.ctp:35 View/Errors/missing_component.ctp:35
+#: View/Errors/missing_connection.ctp:35 View/Errors/missing_controller.ctp:35
+#: View/Errors/missing_database.ctp:27 View/Errors/missing_datasource.ctp:28
+#: View/Errors/missing_datasource_config.ctp:23
+#: View/Errors/missing_helper.ctp:35 View/Errors/missing_layout.ctp:40
+#: View/Errors/missing_plugin.ctp:39 View/Errors/missing_table.ctp:23
+#: View/Errors/missing_view.ctp:40 View/Errors/pdo_error.ctp:33
+#: View/Errors/private_action.ctp:23 View/Errors/scaffold_error.ctp:23
+msgid "Notice"
+msgstr ""
+
+#: View/Errors/fatal_error.ctp:33 View/Errors/missing_action.ctp:39
+#: View/Errors/missing_behavior.ctp:36 View/Errors/missing_component.ctp:36
+#: View/Errors/missing_connection.ctp:36 View/Errors/missing_controller.ctp:36
+#: View/Errors/missing_database.ctp:28 View/Errors/missing_datasource.ctp:29
+#: View/Errors/missing_datasource_config.ctp:24
+#: View/Errors/missing_helper.ctp:36 View/Errors/missing_layout.ctp:41
+#: View/Errors/missing_plugin.ctp:40 View/Errors/missing_table.ctp:24
+#: View/Errors/missing_view.ctp:41 View/Errors/pdo_error.ctp:34
+#: View/Errors/private_action.ctp:24 View/Errors/scaffold_error.ctp:24
+msgid "If you want to customize this error message, create %s"
+msgstr ""
+
+#: View/Errors/missing_action.ctp:18
+msgid "Missing Method in %s"
+msgstr ""
+
+#: View/Errors/missing_action.ctp:20
+msgid "The action %1$s is not defined in controller %2$s"
+msgstr ""
+
+#: View/Errors/missing_action.ctp:24
+msgid "Create %1$s%2$s in file: %3$s."
+msgstr ""
+
+#: View/Errors/missing_behavior.ctp:19
+msgid "Missing Behavior"
+msgstr ""
+
+#: View/Errors/missing_behavior.ctp:22 View/Errors/missing_component.ctp:22
+#: View/Errors/missing_controller.ctp:22 View/Errors/missing_helper.ctp:22
+msgid "%s could not be found."
+msgstr ""
+
+#: View/Errors/missing_behavior.ctp:26 View/Errors/missing_component.ctp:26
+#: View/Errors/missing_controller.ctp:26 View/Errors/missing_helper.ctp:26
+msgid "Create the class %s below in file: %s"
+msgstr ""
+
+#: View/Errors/missing_component.ctp:19
+msgid "Missing Component"
+msgstr ""
+
+#: View/Errors/missing_connection.ctp:17 View/Errors/missing_database.ctp:17
+msgid "Missing Database Connection"
+msgstr ""
+
+#: View/Errors/missing_connection.ctp:20
+msgid "A Database connection using \"%s\" was missing or unable to connect."
+msgstr ""
+
+#: View/Errors/missing_connection.ctp:24
+msgid "The database server returned this error: %s"
+msgstr ""
+
+#: View/Errors/missing_connection.ctp:31
+msgid "%s driver is NOT enabled"
+msgstr ""
+
+#: View/Errors/missing_controller.ctp:19
+msgid "Missing Controller"
+msgstr ""
+
+#: View/Errors/missing_database.ctp:20
+msgid "Scaffold requires a database connection"
+msgstr ""
+
+#: View/Errors/missing_database.ctp:24 View/Errors/missing_layout.ctp:24
+#: View/Errors/missing_view.ctp:24
+msgid "Confirm you have created the file: %s"
+msgstr ""
+
+#: View/Errors/missing_datasource.ctp:19
+msgid "Missing Datasource"
+msgstr ""
+
+#: View/Errors/missing_datasource.ctp:22
+msgid "Datasource class %s could not be found."
+msgstr ""
+
+#: View/Errors/missing_datasource_config.ctp:17
+msgid "Missing Datasource Configuration"
+msgstr ""
+
+#: View/Errors/missing_datasource_config.ctp:20
+msgid "The datasource configuration %1$s was not found in database.php."
+msgstr ""
+
+#: View/Errors/missing_helper.ctp:19
+msgid "Missing Helper"
+msgstr ""
+
+#: View/Errors/missing_layout.ctp:17
+msgid "Missing Layout"
+msgstr ""
+
+#: View/Errors/missing_layout.ctp:20
+msgid "The layout file %s can not be found or does not exist."
+msgstr ""
+
+#: View/Errors/missing_plugin.ctp:17
+msgid "Missing Plugin"
+msgstr ""
+
+#: View/Errors/missing_plugin.ctp:20
+msgid "The application is trying to load a file from the %s plugin"
+msgstr ""
+
+#: View/Errors/missing_plugin.ctp:24
+msgid "Make sure your plugin %s is in the %s directory and was loaded"
+msgstr ""
+
+#: View/Errors/missing_plugin.ctp:32
+msgid "Loading all plugins"
+msgstr ""
+
+#: View/Errors/missing_plugin.ctp:33
+msgid ""
+"If you wish to load all plugins at once, use the following line in your %s "
+"file"
+msgstr ""
+
+#: View/Errors/missing_table.ctp:17
+msgid "Missing Database Table"
+msgstr ""
+
+#: View/Errors/missing_table.ctp:20
+msgid "Table %1$s for model %2$s was not found in datasource %3$s."
+msgstr ""
+
+#: View/Errors/missing_view.ctp:17
+msgid "Missing View"
+msgstr ""
+
+#: View/Errors/missing_view.ctp:20
+msgid "The view for %1$s%2$s was not found."
+msgstr ""
+
+#: View/Errors/pdo_error.ctp:17
+msgid "Database Error"
+msgstr ""
+
+#: View/Errors/pdo_error.ctp:24
+msgid "SQL Query"
+msgstr ""
+
+#: View/Errors/pdo_error.ctp:29
+msgid "SQL Query Params"
+msgstr ""
+
+#: View/Errors/private_action.ctp:17
+msgid "Private Method in %s"
+msgstr ""
+
+#: View/Errors/private_action.ctp:20
+msgid "%s%s cannot be accessed directly."
+msgstr ""
+
+#: View/Errors/scaffold_error.ctp:17
+msgid "Scaffold Error"
+msgstr ""
+
+#: View/Errors/scaffold_error.ctp:20
+msgid "Method _scaffoldError in was not found in the controller"
+msgstr ""
+
+#: View/Helper/CacheHelper.php:161
+msgid "Unable to write view cache file: \"%s\" for \"%s\""
+msgstr ""
+
+#: View/Helper/FormHelper.php:1627
+msgid "Missing field name for FormHelper::%s"
+msgstr ""
+
+#: View/Helper/HtmlHelper.php:1235
+msgid "Cannot load the configuration file. Wrong \"configFile\" configuration."
+msgstr ""
+
+#: View/Helper/HtmlHelper.php:1241
+msgid "Cannot load the configuration file. Unknown reader."
+msgstr ""
+
+#: View/Helper/JsHelper.php:152
+msgid "JsHelper:: Missing Method %s is undefined"
+msgstr ""
+
+#: View/Helper/MootoolsEngineHelper.php:311
+msgid "%s requires a \"drag\" option to properly function"
+msgstr ""
+
+#: View/Helper/NumberHelper.php:63 View/Helper/TextHelper.php:78
+#: View/Helper/TimeHelper.php:61
+msgid "%s could not be found"
+msgstr ""
+
+#: View/Helper/PaginatorHelper.php:99
+msgid "%s does not implement a %s method, it is incompatible with %s"
+msgstr ""


### PR DESCRIPTION
Update for 2.6's version
- update cake.pot file and add cake_dev & cake_console pot files
- update fr po files

Just a question:
when extracting the pot files, a `default.pot` file was created with following lines:

    #: View/ViewBlock.php:78
    msgid "A view block with the name '%s' is already/still open."
    msgstr ""

Do you think we can move this into cake.pot ?