### PR TITLE
phone validation (DE): disallowing text

### DIFF
--- a/Test/Case/Validation/DeValidationTest.php
+++ b/Test/Case/Validation/DeValidationTest.php
@@ -22,6 +22,16 @@ App::uses('DeValidation', 'Localized.Validation');
 class DeValidationTest extends CakeTestCase {
 
 /**
+	 * test the phone method of DeValidation
+	 *
+	 * @return void
+	 */
+	public function testPhone() {
+		$this->assertTrue(DeValidation::phone('0123456789'));
+		$this->assertFalse(DeValidation::phone('sometext'));
+	}
+
+	/**
  * test the postal method of DeValidation
  *
  * @return void

--- a/Validation/DeValidation.php
+++ b/Validation/DeValidation.php
@@ -52,7 +52,7 @@ class DeValidation extends LocalizedValidation {
  * @return bool Success.
  */
 	public static function phone($check) {
-		$pattern = '/[0-9\/. \-]*/';
+		$pattern = '/^[0-9\/. \-]*$/';
 		return (bool)preg_match($pattern, $check);
 	}
 


### PR DESCRIPTION
Currently the regex for DE phone is broken.