### PR TITLE
be more specific on german postals

### DIFF
--- a/src/Validation/DeValidation.php
+++ b/src/Validation/DeValidation.php
@@ -31,7 +31,7 @@ class DeValidation extends LocalizedValidation
      */
     public static function postal($check)
     {
-        $pattern = '/^[0-9]{5}$/';
+        $pattern = '/^(0[1-46-9]\d{3}|[1-357-9]\d{4}|[4][0-24-9]\d{3}|[6][013-9]\d{3})$/';
         return (bool)preg_match($pattern, $check);
     }
 

--- a/tests/TestCase/Validation/DeValidationTest.php
+++ b/tests/TestCase/Validation/DeValidationTest.php
@@ -43,6 +43,20 @@ class DeValidationTest extends TestCase
     public function testPostal()
     {
         $this->assertTrue(DeValidation::postal('51109'));
+        // must have 5 digits
+        $this->assertFalse(DeValidation::postal('1109'));
         $this->assertFalse(DeValidation::postal('051109'));
+        /**
+         * according to wikipedia, some combinations are reserved and therefore not valid
+         * https://de.wikipedia.org/wiki/Liste_der_Postleitregionen_in_Deutschland#F.C3.BCnfstelliges_System_seit_1993
+         */
+        $this->assertFalse(DeValidation::postal('00109'));
+        $this->assertTrue(DeValidation::postal('01109'));
+        $this->assertFalse(DeValidation::postal('05000'));
+        $this->assertTrue(DeValidation::postal('06109'));
+        $this->assertFalse(DeValidation::postal('43000'));
+        $this->assertTrue(DeValidation::postal('44109'));
+        $this->assertFalse(DeValidation::postal('62000'));
+        $this->assertTrue(DeValidation::postal('63109'));
     }
 }

--- a/tests/TestCase/Validation/DeValidationTest.php
+++ b/tests/TestCase/Validation/DeValidationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * German Localized Validation class test case
  *
@@ -13,6 +14,7 @@
  * @since         Localized Plugin v 0.1
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Localized\Test\TestCase\Validation;
 
 use Cake\Localized\Validation\DeValidation;
@@ -24,6 +26,7 @@ use Cake\TestSuite\TestCase;
  */
 class DeValidationTest extends TestCase
 {
+
     /**
      * test the phone method of DeValidation
      *
@@ -37,7 +40,8 @@ class DeValidationTest extends TestCase
 
     /**
      * test the postal method of DeValidation
-     *
+     * according to wikipedia, some combinations are reserved and therefore not valid
+     * https://de.wikipedia.org/wiki/Liste_der_Postleitregionen_in_Deutschland#F.C3.BCnfstelliges_System_seit_1993
      * @return void
      */
     public function testPostal()
@@ -46,10 +50,6 @@ class DeValidationTest extends TestCase
         // must have 5 digits
         $this->assertFalse(DeValidation::postal('1109'));
         $this->assertFalse(DeValidation::postal('051109'));
-        /**
-         * according to wikipedia, some combinations are reserved and therefore not valid
-         * https://de.wikipedia.org/wiki/Liste_der_Postleitregionen_in_Deutschland#F.C3.BCnfstelliges_System_seit_1993
-         */
         $this->assertFalse(DeValidation::postal('00109'));
         $this->assertTrue(DeValidation::postal('01109'));
         $this->assertFalse(DeValidation::postal('05000'));
@@ -59,4 +59,5 @@ class DeValidationTest extends TestCase
         $this->assertFalse(DeValidation::postal('62000'));
         $this->assertTrue(DeValidation::postal('63109'));
     }
+
 }

--- a/tests/TestCase/Validation/DeValidationTest.php
+++ b/tests/TestCase/Validation/DeValidationTest.php
@@ -59,5 +59,4 @@ class DeValidationTest extends TestCase
         $this->assertFalse(DeValidation::postal('62000'));
         $this->assertTrue(DeValidation::postal('63109'));
     }
-
 }


### PR DESCRIPTION
according to
https://de.wikipedia.org/wiki/Liste_der_Postleitregionen_in_Deutschland#
F.C3.BCnfstelliges_System_seit_1993, some combinations are reserved or
not in use. Make validation fail for these postals.