### PR TITLE
Implemented personId for EsValidation

### DIFF
--- a/src/Validation/EsValidation.php
+++ b/src/Validation/EsValidation.php
@@ -24,6 +24,13 @@ use Cake\Network\Exception\NotImplementedException;
 class EsValidation extends LocalizedValidation
 {
     /**
+     * The list of allowed personId codes. Sorted as wee need them.
+     *
+     * @var string
+     */
+    const CODES = 'TRWAGMYFPDXBNJZSQVHLCKE';
+
+    /**
      * Checks a postal code for Spain.
      *
      * @param string $check The value to check.
@@ -51,11 +58,86 @@ class EsValidation extends LocalizedValidation
      * Checks a country specific identification number.
      *
      * @param string $check The value to check.
-     * @throws NotImplementedException Exception
+     * @param array $checks The check types to be performed.
+     *                      Can be either `dni`, `nie` and/or `nif`.
      * @return bool Success.
      */
-    public static function personId($check)
+    public static function personId($check, $checks = [])
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        $default = ['dni', 'nie', 'nif'];
+        if (!empty($checks)) {
+            $checks = array_intersect($default, $checks);
+        } else {
+            $checks = $default;
+        }
+
+        foreach ($checks as $method) {
+            if (self::$method($check)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Only checks the DNI type personId.
+     *
+     * @param  string $check The value to check.
+     * @return bool Success.
+     */
+    public static function dni($check)
+    {
+        if (!preg_match('/^([0-9]+)([A-Z]{1})$/', $check, $matches)) {
+            return false;
+        }
+
+        array_shift($matches);
+        list($num, $letter) = $matches;
+
+        return ($letter == self::CODES[$num % 23]);
+    }
+
+    /**
+     * Only checks the NIE type personId.
+     *
+     * @param  string $check The value to check.
+     * @return bool Success.
+     */
+    public static function nie($check)
+    {
+        if (!preg_match('/^([XYZ])([0-9]+)([A-Z]{1})$/', $check, $matches)) {
+            return false;
+        }
+
+        array_shift($matches);
+        list($first, $num, $letter) = $matches;
+        $num = strtr($first, 'XYZ', '012') . $num;
+
+        return ($letter == self::CODES[$num % 23]);
+    }
+
+    /**
+     * Only checks the NIF type personId.
+     *
+     * @param  string $check The value to check.
+     * @return bool Success
+     */
+    public static function nif($check)
+    {
+        if (!preg_match('/^[KLM]{1}([0-9]+)([A-Z]{1})$/', $check, $matches)) {
+            return false;
+        }
+
+        $sum = $check[2] + $check[4] + $check[6];
+
+        for ($i = 1; $i < 8; $i += 2) {
+            $tmp = (string)(2 * $check[$i]);
+            $sum += $tmp[0] + ((strlen($tmp) == 2) ? $tmp[1] : 0);
+        }
+
+        $num = 10 - substr($sum, -1);
+
+        return $check[strlen($check) - 1] == chr($num + 64);
     }
 }

--- a/src/Validation/EsValidation.php
+++ b/src/Validation/EsValidation.php
@@ -88,7 +88,7 @@ class EsValidation extends LocalizedValidation
         array_shift($matches);
         list($num, $letter) = $matches;
 
-        return ($letter === self::$CODES[$num % 23]);
+        return $letter === self::$CODES[$num % 23];
     }
 
     /**
@@ -107,7 +107,7 @@ class EsValidation extends LocalizedValidation
         list($first, $num, $letter) = $matches;
         $num = strtr($first, 'XYZ', '012') . $num;
 
-        return ($letter === self::$CODES[$num % 23]);
+        return $letter === self::$CODES[$num % 23];
     }
 
     /**

--- a/src/Validation/EsValidation.php
+++ b/src/Validation/EsValidation.php
@@ -88,7 +88,7 @@ class EsValidation extends LocalizedValidation
         array_shift($matches);
         list($num, $letter) = $matches;
 
-        return ($letter == self::$CODES[$num % 23]);
+        return ($letter === self::$CODES[$num % 23]);
     }
 
     /**
@@ -107,7 +107,7 @@ class EsValidation extends LocalizedValidation
         list($first, $num, $letter) = $matches;
         $num = strtr($first, 'XYZ', '012') . $num;
 
-        return ($letter == self::$CODES[$num % 23]);
+        return ($letter === self::$CODES[$num % 23]);
     }
 
     /**
@@ -131,6 +131,6 @@ class EsValidation extends LocalizedValidation
 
         $num = 10 - substr($sum, -1);
 
-        return $check[strlen($check) - 1] == chr($num + 64);
+        return $check[strlen($check) - 1] === chr($num + 64);
     }
 }

--- a/src/Validation/EsValidation.php
+++ b/src/Validation/EsValidation.php
@@ -28,7 +28,7 @@ class EsValidation extends LocalizedValidation
      *
      * @var string
      */
-    private static $CODES = 'TRWAGMYFPDXBNJZSQVHLCKE';
+    protected static $CODES = 'TRWAGMYFPDXBNJZSQVHLCKE';
 
     /**
      * Checks a postal code for Spain.

--- a/src/Validation/EsValidation.php
+++ b/src/Validation/EsValidation.php
@@ -65,7 +65,7 @@ class EsValidation extends LocalizedValidation
         $checks = ['dni', 'nie', 'nif'];
 
         foreach ($checks as $method) {
-            if (self::$method($check)) {
+            if (static::$method($check)) {
                 return true;
             }
         }
@@ -88,7 +88,7 @@ class EsValidation extends LocalizedValidation
         array_shift($matches);
         list($num, $letter) = $matches;
 
-        return $letter === self::$CODES[$num % 23];
+        return $letter === static::$CODES[$num % 23];
     }
 
     /**
@@ -107,7 +107,7 @@ class EsValidation extends LocalizedValidation
         list($first, $num, $letter) = $matches;
         $num = strtr($first, 'XYZ', '012') . $num;
 
-        return $letter === self::$CODES[$num % 23];
+        return $letter === static::$CODES[$num % 23];
     }
 
     /**

--- a/src/Validation/EsValidation.php
+++ b/src/Validation/EsValidation.php
@@ -28,7 +28,7 @@ class EsValidation extends LocalizedValidation
      *
      * @var string
      */
-    const CODES = 'TRWAGMYFPDXBNJZSQVHLCKE';
+    private static $CODES = 'TRWAGMYFPDXBNJZSQVHLCKE';
 
     /**
      * Checks a postal code for Spain.
@@ -62,9 +62,9 @@ class EsValidation extends LocalizedValidation
      *                      Can be either `dni`, `nie` and/or `nif`.
      * @return bool Success.
      */
-    public static function personId($check, $checks = array())
+    public static function personId($check, $checks = [])
     {
-        $default = array('dni', 'nie', 'nif');
+        $default = ['dni', 'nie', 'nif'];
         if (!empty($checks)) {
             $checks = array_intersect($default, $checks);
         } else {
@@ -95,7 +95,7 @@ class EsValidation extends LocalizedValidation
         array_shift($matches);
         list($num, $letter) = $matches;
 
-        return ($letter == self::CODES[$num % 23]);
+        return ($letter == self::$CODES[$num % 23]);
     }
 
     /**
@@ -114,7 +114,7 @@ class EsValidation extends LocalizedValidation
         list($first, $num, $letter) = $matches;
         $num = strtr($first, 'XYZ', '012') . $num;
 
-        return ($letter == self::CODES[$num % 23]);
+        return ($letter == self::$CODES[$num % 23]);
     }
 
     /**

--- a/src/Validation/EsValidation.php
+++ b/src/Validation/EsValidation.php
@@ -76,7 +76,7 @@ class EsValidation extends LocalizedValidation
     /**
      * Only checks the DNI type personId.
      *
-     * @param  string $check The value to check.
+     * @param string $check The value to check.
      * @return bool Success.
      */
     public static function dni($check)
@@ -94,7 +94,7 @@ class EsValidation extends LocalizedValidation
     /**
      * Only checks the NIE type personId.
      *
-     * @param  string $check The value to check.
+     * @param string $check The value to check.
      * @return bool Success.
      */
     public static function nie($check)
@@ -113,7 +113,7 @@ class EsValidation extends LocalizedValidation
     /**
      * Only checks the NIF type personId.
      *
-     * @param  string $check The value to check.
+     * @param string $check The value to check.
      * @return bool Success
      */
     public static function nif($check)

--- a/src/Validation/EsValidation.php
+++ b/src/Validation/EsValidation.php
@@ -62,9 +62,9 @@ class EsValidation extends LocalizedValidation
      *                      Can be either `dni`, `nie` and/or `nif`.
      * @return bool Success.
      */
-    public static function personId($check, $checks = [])
+    public static function personId($check, $checks = array())
     {
-        $default = ['dni', 'nie', 'nif'];
+        $default = array('dni', 'nie', 'nif');
         if (!empty($checks)) {
             $checks = array_intersect($default, $checks);
         } else {

--- a/src/Validation/EsValidation.php
+++ b/src/Validation/EsValidation.php
@@ -58,18 +58,11 @@ class EsValidation extends LocalizedValidation
      * Checks a country specific identification number.
      *
      * @param string $check The value to check.
-     * @param array $checks The check types to be performed.
-     *                      Can be either `dni`, `nie` and/or `nif`.
      * @return bool Success.
      */
-    public static function personId($check, $checks = [])
+    public static function personId($check)
     {
-        $default = ['dni', 'nie', 'nif'];
-        if (!empty($checks)) {
-            $checks = array_intersect($default, $checks);
-        } else {
-            $checks = $default;
-        }
+        $checks = ['dni', 'nie', 'nif'];
 
         foreach ($checks as $method) {
             if (self::$method($check)) {

--- a/tests/TestCase/Validation/EsValidationTest.php
+++ b/tests/TestCase/Validation/EsValidationTest.php
@@ -58,4 +58,65 @@ class EsValidationTest extends TestCase
         $this->assertFalse(EsValidation::phone('813 4567'));
         $this->assertFalse(EsValidation::phone('(666) 232 323'));
     }
+
+    /**
+     * test the personId method of EsValidation
+     *
+     * @return void
+     */
+    public function testPersonId()
+    {
+        $this->assertTrue(EsValidation::personId('32050031Z'));
+        $this->assertTrue(EsValidation::personId('X2546874S'));
+        $this->assertTrue(EsValidation::personId('K1254868A'));
+        $this->assertTrue(EsValidation::personId('K1254868A', ['nif', 'nie']));
+
+        $this->assertFalse(EsValidation::personId('X2546874S', ['dni']));
+        $this->assertFalse(EsValidation::personId('32050031Z', ['nif']));
+        $this->assertFalse(EsValidation::personId('K1254868A', ['nie']));
+    }
+
+    /**
+     * Test the dni validation.
+     *
+     * @return void
+     */
+    public function testDni()
+    {
+        $this->assertTrue(EsValidation::dni('32050031Z'));
+        $this->assertTrue(EsValidation::dni('03654968S'));
+        $this->assertTrue(EsValidation::dni('00000014Z'));
+        $this->assertTrue(EsValidation::dni('14Z'));
+        $this->assertFalse(EsValidation::dni('145'));
+        $this->assertFalse(EsValidation::dni('21856874H'));
+    }
+
+    /**
+     * Test the nie validation.
+     *
+     * @return void
+     */
+    public function testNie()
+    {
+        $this->assertTrue(EsValidation::nie('X2546874S'));
+        $this->assertTrue(EsValidation::nie('Y2332323E'));
+        $this->assertTrue(EsValidation::nie('Z2548769Y'));
+        $this->assertFalse(EsValidation::nie('35489765Y'));
+        $this->assertFalse(EsValidation::nie('123456'));
+    }
+
+    /**
+     * Test the nif validation.
+     *
+     * @return void
+     */
+    public function testNif()
+    {
+        $this->assertTrue(EsValidation::nif('K1254868A'));
+        $this->assertTrue(EsValidation::nif('K3548762H'));
+        $this->assertTrue(EsValidation::nif('L5876542A'));
+        $this->assertFalse(EsValidation::nif('X5876542A'));
+        $this->assertFalse(EsValidation::nif('Z2548769Y'));
+        $this->assertFalse(EsValidation::nif('32050031Z'));
+    }
 }

--- a/tests/TestCase/Validation/EsValidationTest.php
+++ b/tests/TestCase/Validation/EsValidationTest.php
@@ -69,11 +69,8 @@ class EsValidationTest extends TestCase
         $this->assertTrue(EsValidation::personId('32050031Z'));
         $this->assertTrue(EsValidation::personId('X2546874S'));
         $this->assertTrue(EsValidation::personId('K1254868A'));
-        $this->assertTrue(EsValidation::personId('K1254868A', ['nif', 'nie']));
 
-        $this->assertFalse(EsValidation::personId('X2546874S', ['dni']));
-        $this->assertFalse(EsValidation::personId('32050031Z', ['nif']));
-        $this->assertFalse(EsValidation::personId('K1254868A', ['nie']));
+        $this->assertFalse(EsValidation::personId('23232323'));
     }
 
     /**


### PR DESCRIPTION
As said in #117 we have more than one personId type. For that reason I've created three methods (a part from the `personId` itself):

- **dni**: checks personId's of type `dni`. These are the common personIds.
- **nif**: checks personId's of type `nif`. These begin with `K`, `L` or `M`.
- **nie**: checks personId's of type `nie`. These begin with `X`, `Y` or `Z`.

For this reason, I've implemented `personId` to check all them by default, but you can specify which types you wanna check with its second parameter:

~~~php
EsValidation::personId('whatever'); // checks all types.
EsValidation::personId('whatever', ['dni']); // only checks dni type.
EsValidation::dni('whatever'); // same as above, but using its proper method.
EsValidation::personId('whatever', ['dni', 'nif']); // only checks dni and nif types.
~~~