### PR TITLE
[GB] Optional postcode space

### DIFF
--- a/src/Validation/GbValidation.php
+++ b/src/Validation/GbValidation.php
@@ -29,7 +29,7 @@ class GbValidation extends LocalizedValidation
      */
     public static function postal($check)
     {
-        $pattern = '/\\A\\b[A-Z]{1,2}[0-9][A-Z0-9]? [0-9][ABD-HJLNP-UW-Z]{2}\\b\\z/i';
+        $pattern = '/\\A\\b[A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][ABD-HJLNP-UW-Z]{2}\\b\\z/i';
 
         return (bool)preg_match($pattern, $check);
     }

--- a/tests/TestCase/Validation/GbValidationTest.php
+++ b/tests/TestCase/Validation/GbValidationTest.php
@@ -29,7 +29,20 @@ class GbValidationTest extends TestCase
      */
     public function testPostal()
     {
-        $this->assertTrue(GbValidation::postal('DT4 8PP'));
         $this->assertFalse(GbValidation::postal('DT4-8PP'));
+        $this->assertTrue(GbValidation::postal('sp110qn'));
+        $this->assertTrue(GbValidation::postal('SP110QN'));
+        $this->assertTrue(GbValidation::postal('DT4 8PP'));
+        $this->assertTrue(GbValidation::postal('W1A 1AA'));
+        $this->assertTrue(GbValidation::postal('W12 7TQ'));
+        $this->assertTrue(GbValidation::postal('SW1A 0AA'));
+        $this->assertTrue(GbValidation::postal('W1J 7NT'));
+        $this->assertTrue(GbValidation::postal('EC1A 1BB'));
+        $this->assertTrue(GbValidation::postal('W1A 0AX'));
+        $this->assertTrue(GbValidation::postal('M1 1AE'));
+        $this->assertTrue(GbValidation::postal('B33 8TH'));
+        $this->assertTrue(GbValidation::postal('CR2 6XH'));
+        $this->assertTrue(GbValidation::postal('XM45HQ'));
+        $this->assertFalse(GbValidation::postal('SAN TA1'));
     }
 }


### PR DESCRIPTION
Make the space between the two parts of the postcode optional. Most developers normalize the postcode by removing the space, which causes this validation rule to fail.

Although I would prefer to allow both lowercase and uppercase, a call to `strtoupper()` isn't a big deal.