### PR TITLE
Fixed bug JpValidation::phone()

### DIFF
--- a/src/Validation/JpValidation.php
+++ b/src/Validation/JpValidation.php
@@ -47,7 +47,7 @@ class JpValidation extends LocalizedValidation
      */
     public static function phone($check)
     {
-        $pattern = '/^(?:(?:0|\+81[\s\-]?)[1-9](?:0(?:\d{8}|(?:[\s\-]\d{4}){2})|(?:[1-9]\d{7}|(?:[1-9]0(?:[\s\-]\d{3}){2}|[\s\-]\d{4}[\s\-]\d{4}|[1-9]\d{1,2}[\s\-]\d{1,4}[\s\-]\d{4}))))$/';
+        $pattern = '/^(?:(?:0120(?:[\s\-]?\d{3}){2})|(?:0|\+81[\s\-]?)[1-9](?:(?:0[\s\-]?\d{4})|(?:[1-9](?:\d{3}|\d{1}[\s\-]\d{2}|\d{2}[\s\-]\d{1}|[\s\-]\d{3}))|(?:[\s\-]\d{4}))(?:[\s\-]?\d{4}))$/';
 
         return (bool)preg_match($pattern, $check);
     }

--- a/tests/TestCase/Validation/JpValidationTest.php
+++ b/tests/TestCase/Validation/JpValidationTest.php
@@ -31,6 +31,11 @@ class JpValidationTest extends TestCase
      */
     public function testPhone()
     {
+        $this->assertTrue(JpValidation::phone('01-2222-3333'));
+        $this->assertTrue(JpValidation::phone('011-222-3333'));
+        $this->assertTrue(JpValidation::phone('0111-22-3333'));
+        $this->assertTrue(JpValidation::phone('0110-22-3333'));
+        $this->assertTrue(JpValidation::phone('01111-2-3333'));
         $this->assertTrue(JpValidation::phone('03-1111-2222'));
         $this->assertTrue(JpValidation::phone('090-1111-2222'));
         $this->assertTrue(JpValidation::phone('0120-111-222'));
@@ -41,12 +46,23 @@ class JpValidationTest extends TestCase
         $this->assertTrue(JpValidation::phone('03 1111 2222'));
         $this->assertTrue(JpValidation::phone('090 1111 2222'));
         $this->assertTrue(JpValidation::phone('0120 111 222'));
+        $this->assertTrue(JpValidation::phone('+81 1 2222 3333'));
+        $this->assertTrue(JpValidation::phone('+81-1-2222-3333'));
+        $this->assertTrue(JpValidation::phone('+81122223333'));
         $this->assertTrue(JpValidation::phone('+81 90 1111 2222'));
         $this->assertTrue(JpValidation::phone('+81-90-1111-2222'));
         $this->assertTrue(JpValidation::phone('+819011112222'));
 
+        $this->assertFalse(JpValidation::phone('01-2222-33333'));
+        $this->assertFalse(JpValidation::phone('01-22222-3333'));
+        $this->assertFalse(JpValidation::phone('011-2222-3333'));
+        $this->assertFalse(JpValidation::phone('01 2222 33333'));
+        $this->assertFalse(JpValidation::phone('01 22222 3333'));
+        $this->assertFalse(JpValidation::phone('011 2222 3333'));
         $this->assertFalse(JpValidation::phone('03-1111-22223'));
         $this->assertFalse(JpValidation::phone('090-1111-222'));
+        $this->assertFalse(JpValidation::phone('090-111-2222'));
+        $this->assertFalse(JpValidation::phone('0120-111-2222'));
         $this->assertFalse(JpValidation::phone('0120-1111-222'));
         $this->assertFalse(JpValidation::phone('0111-11-222'));
         $this->assertFalse(JpValidation::phone('02222-1-111'));


### PR DESCRIPTION
There was a bug in the pull request I sent before.
"011-222-3333" case was false.

At the same time I did optimization of regex.
[Regexper](https://regexper.com/#%2F%5E(%3F%3A(%3F%3A0120(%3F%3A%5B%5Cs%5C-%5D%3F%5Cd%7B3%7D)%7B2%7D)%7C(%3F%3A0%7C%5C%2B81%5B%5Cs%5C-%5D%3F)%5B1-9%5D(%3F%3A(%3F%3A0%5B%5Cs%5C-%5D%3F%5Cd%7B4%7D)%7C(%3F%3A%5B1-9%5D(%3F%3A%5Cd%7B3%7D%7C%5Cd%7B1%7D%5B%5Cs%5C-%5D%5Cd%7B2%7D%7C%5Cd%7B2%7D%5B%5Cs%5C-%5D%5Cd%7B1%7D%7C%5B%5Cs%5C-%5D%5Cd%7B3%7D))%7C(%3F%3A%5B%5Cs%5C-%5D%5Cd%7B4%7D))(%3F%3A%5B%5Cs%5C-%5D%3F%5Cd%7B4%7D))%24%2F)