### PR TITLE
Add Tunisia Translation and Validation

### DIFF
--- a/src/Locale/ar_TN/cake.po
+++ b/src/Locale/ar_TN/cake.po
@@ -1,0 +1,424 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: CakePHP Arabic Tunisia Translation\n"
+"POT-Creation-Date: 2015-01-19 07:43+0000\n"
+"PO-Revision-Date: 2017-09-21 11:18+0100\n"
+"Last-Translator: BENFARHAT Elyes <benfarhat.elyes@gmail.com>\n"
+"Language-Team: LANGUAGE <benfarhat.elyes@gmail.com>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
+"Language: ar_TN\n"
+"X-Generator: Poedit 2.0.3\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#: View/Errors/error400.ctp:19 View/Errors/error500.ctp:19
+msgid "Error"
+msgstr "خطأ"
+
+#: View/Errors/error400.ctp:21
+msgid "The requested address %s was not found on this server."
+msgstr "العنوان المطلوب %s غير موجود"
+
+#: View/Errors/error500.ctp:20 Error/ExceptionRenderer.php:245
+msgid "An Internal Error Has Occurred."
+msgstr "حدث خطأ داخلي."
+
+#: Controller/Scaffold.php:127
+msgid "Scaffold :: "
+msgstr ""
+
+#: Controller/Scaffold.php:166;233;302
+msgid "Invalid %s"
+msgstr "‏%s غير صحيح"
+
+#: Controller/Scaffold.php:221
+msgid "updated"
+msgstr "تم عملية التحديث"
+
+#: Controller/Scaffold.php:224
+msgid "saved"
+msgstr "تم عملية الحفظ"
+
+#: Controller/Scaffold.php:244
+msgid "The %1$s has been %2$s"
+msgstr "%1$s تم %2$s"
+
+#: Controller/Scaffold.php:254
+msgid "Please correct errors below."
+msgstr "يرجى تصحيح الأخطاء أدناه."
+
+#: Controller/Scaffold.php:305
+msgid "The %1$s with id: %2$s has been deleted."
+msgstr "تم حذف %1$s ذات رمز التعريف %2$s"
+
+#: Controller/Scaffold.php:308
+msgid "There was an error deleting the %1$s with id: %2$s"
+msgstr "حدث خطأ أثناء حذف %1$s ذات رمز التعريف %2$s"
+
+#: Controller/Component/AuthComponent.php:432
+msgid "You are not authorized to access that location."
+msgstr "لا تملك صلاحية الدخول إلى هذه الصفحة"
+
+#: Error/ExceptionRenderer.php:222
+msgid "Not Found"
+msgstr "غير موجود"
+
+#: Model/Validator/CakeValidationSet.php:286
+msgid "This field cannot be left blank"
+msgstr "لا يمكن ترك هذا الحقل فارغا"
+
+#: Network/CakeResponse.php:1355
+msgid "The requested file was not found"
+msgstr "لم يتم العثور على الملف المطلوب"
+
+#: Utility/CakeNumber.php:119
+msgid "%s KB"
+msgstr "‏%s كيلوبايت"
+
+#: Utility/CakeNumber.php:121
+msgid "%s MB"
+msgstr "‏%s ميغابايت"
+
+#: Utility/CakeNumber.php:123
+msgid "%s GB"
+msgstr "%s جيقابايت"
+
+#: Utility/CakeNumber.php:125
+msgid "%s TB"
+msgstr "‏%s تيرابايت"
+
+#: Utility/CakeNumber.php:117
+msgid "%d Byte"
+msgid_plural "%d Bytes"
+msgstr[0] "‏%d بايت"
+msgstr[1] "‏%d بايت"
+msgstr[2] "‏%d بايت"
+msgstr[3] "‏%d بايت"
+msgstr[4] "‏%d بايت"
+msgstr[5] "‏%d بايت"
+
+#: Utility/CakeTime.php:397
+msgid "Today, %s"
+msgstr "اليوم %s"
+
+#: Utility/CakeTime.php:400
+msgid "Yesterday, %s"
+msgstr "أمس %s"
+
+#: Utility/CakeTime.php:403
+msgid "Tomorrow, %s"
+msgstr "غدا %s"
+
+#: Utility/CakeTime.php:408
+msgid "Sunday"
+msgstr "الأحد"
+
+#: Utility/CakeTime.php:409
+msgid "Monday"
+msgstr "الاثنين"
+
+#: Utility/CakeTime.php:410
+msgid "Tuesday"
+msgstr "الثلاثاء"
+
+#: Utility/CakeTime.php:411
+msgid "Wednesday"
+msgstr "الأربعاء"
+
+#: Utility/CakeTime.php:412
+msgid "Thursday"
+msgstr "الخميس"
+
+#: Utility/CakeTime.php:413
+msgid "Friday"
+msgstr "الجمعة"
+
+#: Utility/CakeTime.php:414
+msgid "Saturday"
+msgstr "السبت"
+
+#: Utility/CakeTime.php:420
+msgid "On %s %s"
+msgstr "في %s %s"
+
+#: Utility/CakeTime.php:743
+msgid "%s ago"
+msgstr "‏%s خلت"
+
+#: Utility/CakeTime.php:744
+msgid "in %s"
+msgstr "في %s"
+
+#: Utility/CakeTime.php:745
+msgid "on %s"
+msgstr "في %s"
+
+#: Utility/CakeTime.php:801
+msgid "just now"
+msgstr "الآن"
+
+#: Utility/CakeTime.php:924
+msgid "in about a second"
+msgstr "في حوالي ثانية"
+
+#: Utility/CakeTime.php:925
+msgid "in about a minute"
+msgstr "في حوالي دقيقة"
+
+#: Utility/CakeTime.php:926
+msgid "in about an hour"
+msgstr "في حوالي ساعة"
+
+#: Utility/CakeTime.php:927
+msgid "in about a day"
+msgstr "في حوالي يوم"
+
+#: Utility/CakeTime.php:928
+msgid "in about a week"
+msgstr "في حوالي أسبوع"
+
+#: Utility/CakeTime.php:929
+msgid "in about a year"
+msgstr "في حوالي سنة"
+
+#: Utility/CakeTime.php:933
+msgid "about a second ago"
+msgstr "قبل نحو ثانية"
+
+#: Utility/CakeTime.php:934
+msgid "about a minute ago"
+msgstr "قبل نحو دقيقة"
+
+#: Utility/CakeTime.php:935
+msgid "about an hour ago"
+msgstr "قبل نحو ساعة"
+
+#: Utility/CakeTime.php:936
+msgid "about a day ago"
+msgstr "قبل نحو يوم"
+
+#: Utility/CakeTime.php:937
+msgid "about a week ago"
+msgstr "قبل نحو أسبوع"
+
+#: Utility/CakeTime.php:938
+msgid "about a year ago"
+msgstr "قبل نحو سنة"
+
+#: Utility/CakeTime.php:958;980
+msgid "days"
+msgstr "أيام"
+
+#: Utility/CakeTime.php:895
+msgid "%d year"
+msgid_plural "%d years"
+msgstr[0] "%d سنة"
+msgstr[1] "سنة واحدة"
+msgstr[2] "سنتين"
+msgstr[3] "%d سنوات"
+msgstr[4] "%d سنة"
+msgstr[5] "%d سنة"
+
+#: Utility/CakeTime.php:898
+msgid "%d month"
+msgid_plural "%d months"
+msgstr[0] "%d شهر"
+msgstr[1] "شهر واحد"
+msgstr[2] "شهرين"
+msgstr[3] "%d أشهر"
+msgstr[4] "%d شهر"
+msgstr[5] "%d شهر"
+
+#: Utility/CakeTime.php:901
+msgid "%d week"
+msgid_plural "%d weeks"
+msgstr[0] "%d أسبوع"
+msgstr[1] "أسبوع واحد"
+msgstr[2] "أسبوعين"
+msgstr[3] "%d أسابيع"
+msgstr[4] "%d أسبوع"
+msgstr[5] "%d أسبوع"
+
+#: Utility/CakeTime.php:904
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] "%d يوم"
+msgstr[1] "يوم واحد"
+msgstr[2] "يومين"
+msgstr[3] "%d أيام"
+msgstr[4] "%d يوم"
+msgstr[5] "%d يوم"
+
+#: Utility/CakeTime.php:907
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d ساعة"
+msgstr[1] "ساعة واحدة"
+msgstr[2] "ساعتين"
+msgstr[3] "%d ساعات"
+msgstr[4] "%d ساعة"
+msgstr[5] "%d ساعة"
+
+#: Utility/CakeTime.php:910
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d دقيقة"
+msgstr[1] "دقيقة واحدة"
+msgstr[2] "دقيقتين"
+msgstr[3] "%d دقائق"
+msgstr[4] "%d دقيقة"
+msgstr[5] "%d دقيقة"
+
+#: Utility/CakeTime.php:913
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d ثانية"
+msgstr[1] "ثانية واحدة"
+msgstr[2] "ثانيتين"
+msgstr[3] "%d ثواني"
+msgstr[4] "%d ثانية"
+msgstr[5] "%d ثانية"
+
+#: Utility/String.php:701
+msgid "and"
+msgstr "و"
+
+#: View/Helper/FormHelper.php:732
+msgid "Error in field %s"
+msgstr "خطأ في الحقل %s"
+
+#: View/Helper/FormHelper.php:921 View/Scaffolds/form.ctp:46
+#: View/Scaffolds/index.ctp:77;92 View/Scaffolds/view.ctp:63;78;188
+msgid "New %s"
+msgstr "‏%s جديد"
+
+#: View/Helper/FormHelper.php:927 View/Scaffolds/view.ctp:51;109
+msgid "Edit %s"
+msgstr "تعديل %s"
+
+#: View/Helper/FormHelper.php:1500
+msgid "empty"
+msgstr "فارغ"
+
+#: View/Helper/FormHelper.php:1895 View/Scaffolds/form.ctp:21
+msgid "Submit"
+msgstr "إرسال"
+
+#: View/Helper/FormHelper.php:2874
+msgid "January"
+msgstr "جانفي"
+
+#: View/Helper/FormHelper.php:2875
+msgid "February"
+msgstr "فيفري"
+
+#: View/Helper/FormHelper.php:2876
+msgid "March"
+msgstr "مارس"
+
+#: View/Helper/FormHelper.php:2877
+msgid "April"
+msgstr "أفريل"
+
+#: View/Helper/FormHelper.php:2878
+msgid "May"
+msgstr "ماي"
+
+#: View/Helper/FormHelper.php:2879
+msgid "June"
+msgstr "جوان"
+
+#: View/Helper/FormHelper.php:2880
+msgid "July"
+msgstr "جويلية"
+
+#: View/Helper/FormHelper.php:2881
+msgid "August"
+msgstr "أوت"
+
+#: View/Helper/FormHelper.php:2882
+msgid "September"
+msgstr "سبتمبر"
+
+#: View/Helper/FormHelper.php:2883
+msgid "October"
+msgstr "أكتوبر"
+
+#: View/Helper/FormHelper.php:2884
+msgid "November"
+msgstr "نوفمبر"
+
+#: View/Helper/FormHelper.php:2885
+msgid "December"
+msgstr "ديسمبر"
+
+#: View/Helper/HtmlHelper.php:782
+msgid "Home"
+msgstr "الرئيسية"
+
+#: View/Helper/PaginatorHelper.php:637
+msgid " of "
+msgstr "من"
+
+#: View/Scaffolds/form.ctp:25 View/Scaffolds/index.ctp:24;75
+#: View/Scaffolds/view.ctp:47
+msgid "Actions"
+msgstr "عمليات"
+
+#: View/Scaffolds/form.ctp:29 View/Scaffolds/index.ctp:49
+#: View/Scaffolds/view.ctp:173
+msgid "Delete"
+msgstr "حذف"
+
+#: View/Scaffolds/form.ctp:32 View/Scaffolds/index.ctp:52
+#: View/Scaffolds/view.ctp:55;176
+msgid "Are you sure you want to delete # %s?"
+msgstr "هل تريد فعلا حذف # %s؟"
+
+#: View/Scaffolds/form.ctp:35
+msgid "List"
+msgstr "القائمة"
+
+#: View/Scaffolds/form.ctp:42 View/Scaffolds/index.ctp:85
+#: View/Scaffolds/view.ctp:59;72
+msgid "List %s"
+msgstr "قائمة %s"
+
+#: View/Scaffolds/index.ctp:46 View/Scaffolds/view.ctp:161
+msgid "View"
+msgstr "عرض"
+
+#: View/Scaffolds/index.ctp:47 View/Scaffolds/view.ctp:167
+msgid "Edit"
+msgstr "تعديل"
+
+#: View/Scaffolds/index.ctp:63
+msgid ""
+"Page {:page} of {:pages}, showing {:current} records out of {:count} total, "
+"starting on record {:start}, ending on {:end}"
+msgstr ""
+"الصفحة {:page} من {:page}, اظهار {:current} من أصل {:count} بيانات مسجلة, "
+"بداية من {:start} وانتهاءا بـ {:end}"
+
+#: View/Scaffolds/index.ctp:68
+msgid "previous"
+msgstr "السابق"
+
+#: View/Scaffolds/index.ctp:70
+msgid "next"
+msgstr "التالي"
+
+#: View/Scaffolds/view.ctp:18
+msgid "View %s"
+msgstr "مشاهدة %s"
+
+#: View/Scaffolds/view.ctp:55
+msgid "Delete %s"
+msgstr "حذف %s"
+
+#: View/Scaffolds/view.ctp:93;133
+msgid "Related %s"
+msgstr "مرتبطة بـ %s"

--- a/src/Validation/TnValidation.php
+++ b/src/Validation/TnValidation.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Tunisia Localized Validation class. Handles localized validation for Tunisia.
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org
+ * @since         Localized Plugin v 0.1
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Localized\Validation;
+
+/**
+ * TnValidation
+ *
+ */
+class TnValidation extends LocalizedValidation
+{
+    /**
+     * Checks a phone number for Tunisia.
+     *
+     * @param string $check The value to check.
+     * @return bool Success.
+     */
+    public static function phone($check)
+    {
+        // Tunisia telephone numbers
+        // source : https://en.wikipedia.org/wiki/Telephone_numbers_in_Tunisia
+        $pattern = '/^(00216|\+216){0,1}[7]([0-9]{7})$/';
+
+        return (bool)preg_match($pattern, $check);
+    }
+    /**
+     * Checks mobile numbers for Tunisia.
+     *
+     * @param string $check The value to check.
+     * @return bool Success.
+     */
+    public static function mobile($check)
+    {
+        // Tunisia mobile numbers
+        // source : https://en.wikipedia.org/wiki/Telephone_numbers_in_Tunisia
+        $pattern = '/^(00216|\+216){0,1}(2|4|5|9)([0-9]{7})$/';
+
+        return (bool)preg_match($pattern, $check);
+    }
+    /**
+     * Checks a postal code for Tunisia.
+     *
+     * @param string $check The value to check.
+     * @return bool Success.
+     */
+    public static function postal($check)
+    {
+        // Tunisia postal code
+        // source : https://en.wikipedia.org/wiki/Postal_codes_in_Tunisia
+        $pattern = '/^[1-9][0-2][0-9]{2}$/';
+
+        return (bool)preg_match($pattern, $check);
+    }
+
+    /**
+     * Checks an identity social security number for Tunisia.
+     *
+     * @param string $check The value to check.
+     * @return bool Success.
+     */
+    public static function personId($check)
+    {
+        $pattern = '/^[0-9]{8,9}$/';
+
+        return (bool)preg_match($pattern, $check);
+    }
+}

--- a/src/Validation/TnValidation.php
+++ b/src/Validation/TnValidation.php
@@ -29,23 +29,9 @@ class TnValidation extends LocalizedValidation
      */
     public static function phone($check)
     {
-        // Tunisia telephone numbers
-        // source : https://en.wikipedia.org/wiki/Telephone_numbers_in_Tunisia
-        $pattern = '/^(00216|\+216){0,1}[7]([0-9]{7})$/';
-
-        return (bool)preg_match($pattern, $check);
-    }
-    /**
-     * Checks mobile numbers for Tunisia.
-     *
-     * @param string $check The value to check.
-     * @return bool Success.
-     */
-    public static function mobile($check)
-    {
         // Tunisia mobile numbers
         // source : https://en.wikipedia.org/wiki/Telephone_numbers_in_Tunisia
-        $pattern = '/^(00216|\+216){0,1}(2|4|5|9)([0-9]{7})$/';
+        $pattern = '/^(00216|\+216){0,1}(2|4|5|7|9)([0-9]{7})$/';
 
         return (bool)preg_match($pattern, $check);
     }

--- a/src/Validation/TnValidation.php
+++ b/src/Validation/TnValidation.php
@@ -26,32 +26,31 @@ class TnValidation extends LocalizedValidation
      *
      * @param string $check The value to check.
      * @return bool Success.
+     * @see https://en.wikipedia.org/wiki/Telephone_numbers_in_Tunisia
      */
     public static function phone($check)
     {
-        // Tunisia mobile numbers
-        // source : https://en.wikipedia.org/wiki/Telephone_numbers_in_Tunisia
         $pattern = '/^(00216|\+216){0,1}(2|4|5|7|9)([0-9]{7})$/';
 
         return (bool)preg_match($pattern, $check);
     }
+
     /**
      * Checks a postal code for Tunisia.
      *
      * @param string $check The value to check.
      * @return bool Success.
+     * @see https://en.wikipedia.org/wiki/Postal_codes_in_Tunisia
      */
     public static function postal($check)
     {
-        // Tunisia postal code
-        // source : https://en.wikipedia.org/wiki/Postal_codes_in_Tunisia
         $pattern = '/^[1-9][0-2][0-9]{2}$/';
 
         return (bool)preg_match($pattern, $check);
     }
 
     /**
-     * Checks an identity social security number for Tunisia.
+     * Checks a Tunisian identification number.
      *
      * @param string $check The value to check.
      * @return bool Success.

--- a/tests/TestCase/Validation/TnValidationTest.php
+++ b/tests/TestCase/Validation/TnValidationTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tunisia Localized Validation class test case
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org
+ * @since         Localized Plugin v 0.1
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Localized\Test\TestCase\Validation;
+
+use Cake\Localized\Validation\TnValidation;
+use Cake\TestSuite\TestCase;
+
+/**
+ * TnValidationTest
+ *
+ */
+class TnValidationTest extends TestCase
+{
+    /**
+     * test the phone method of TnValidation
+     *
+     * @return void
+     */
+    public function testPhone()
+    {
+        $this->assertTrue(TnValidation::phone('0021671000000'));
+        $this->assertTrue(TnValidation::phone('+21671000000'));
+        $this->assertTrue(TnValidation::phone('71000000'));
+        $this->assertTrue(TnValidation::phone('70999999'));
+        $this->assertFalse(TnValidation::phone('21671000000'));
+        $this->assertFalse(TnValidation::phone('+0021671000000'));
+        $this->assertFalse(TnValidation::phone('22000000'));
+        $this->assertFalse(TnValidation::phone('71 000 000'));
+        $this->assertFalse(TnValidation::phone('7100000'));
+        $this->assertFalse(TnValidation::phone('710000000'));
+        $this->assertFalse(TnValidation::phone(true));
+        $this->assertFalse(TnValidation::phone('abcdef'));
+    }
+    /**
+     * test the mobile method of TnValidation
+     *
+     * @return void
+     */
+    public function testMobile()
+    {
+        $this->assertTrue(TnValidation::mobile('0021622000000'));
+        $this->assertTrue(TnValidation::mobile('0021698000000'));
+        $this->assertTrue(TnValidation::mobile('0021651000000'));
+        $this->assertTrue(TnValidation::mobile('+21640000000'));
+        $this->assertTrue(TnValidation::mobile('22000000'));
+        $this->assertTrue(TnValidation::mobile('98999999'));
+        $this->assertTrue(TnValidation::mobile('98999999'));
+        $this->assertTrue(TnValidation::mobile('4012345678'));
+        $this->assertFalse(TnValidation::mobile('+0021622000000'));
+        $this->assertFalse(TnValidation::mobile('0021398000000'));
+        $this->assertFalse(TnValidation::mobile('0021671000000'));
+        $this->assertFalse(TnValidation::mobile('+21630000000'));
+        $this->assertFalse(TnValidation::mobile('60000000'));
+        $this->assertFalse(TnValidation::mobile('9899999'));
+        $this->assertFalse(TnValidation::mobile('989999999'));
+        $this->assertFalse(TnValidation::mobile('004012345678'));
+        $this->assertFalse(TnValidation::mobile(false));
+        $this->assertFalse(TnValidation::mobile('abcdef'));
+    }
+    /**
+     * test the postal method of TnValidation
+     *
+     * @return void
+     */
+    public function testPostal()
+    {
+        $this->assertTrue(TnValidation::postal('1000'));
+        $this->assertTrue(TnValidation::postal('4100'));
+        $this->assertTrue(TnValidation::postal('6020'));
+        $this->assertTrue(TnValidation::postal('8225'));
+        $this->assertTrue(TnValidation::postal('9055'));
+        $this->assertFalse(TnValidation::postal('0000'));
+        $this->assertFalse(TnValidation::postal('4300'));
+        $this->assertFalse(TnValidation::postal('6920'));
+        $this->assertFalse(TnValidation::postal('82250'));
+        $this->assertFalse(TnValidation::postal('901'));
+        $this->assertFalse(TnValidation::postal('90 11'));
+        $this->assertFalse(TnValidation::postal(''));
+        $this->assertFalse(TnValidation::postal(' '));
+        $this->assertFalse(TnValidation::postal('abcd'));
+        $this->assertFalse(TnValidation::postal('1'));
+        $this->assertFalse(TnValidation::postal('10'));
+        $this->assertFalse(TnValidation::postal(true));
+    }
+    /**
+     * test the personId method of TnValidation
+     *
+     * @return void
+     */
+    public function testPersonId()
+    {
+        $this->assertTrue(TnValidation::personId('12345678'));
+        $this->assertTrue(TnValidation::personId('123456789'));
+        $this->assertTrue(TnValidation::personId('00000000'));
+        $this->assertTrue(TnValidation::personId('999999999'));
+        $this->assertFalse(TnValidation::personId('1234567'));
+        $this->assertFalse(TnValidation::personId('0123456789'));
+        $this->assertFalse(TnValidation::personId('1234 56798'));
+        $this->assertFalse(TnValidation::personId('01234 567989'));
+        $this->assertFalse(TnValidation::personId(true));
+        $this->assertFalse(TnValidation::personId('abcdefgh'));
+    }
+}

--- a/tests/TestCase/Validation/TnValidationTest.php
+++ b/tests/TestCase/Validation/TnValidationTest.php
@@ -42,7 +42,7 @@ class TnValidationTest extends TestCase
         $this->assertTrue(TnValidation::phone('22000000'));
         $this->assertTrue(TnValidation::phone('98999999'));
         $this->assertTrue(TnValidation::phone('98999999'));
-        $this->assertTrue(TnValidation::phone('4012345678'));       
+        $this->assertTrue(TnValidation::phone('412345678'));       
         $this->assertFalse(TnValidation::phone('21671000000'));
         $this->assertFalse(TnValidation::phone('+00216'));
         $this->assertFalse(TnValidation::phone('0021398000000'));

--- a/tests/TestCase/Validation/TnValidationTest.php
+++ b/tests/TestCase/Validation/TnValidationTest.php
@@ -33,42 +33,29 @@ class TnValidationTest extends TestCase
     {
         $this->assertTrue(TnValidation::phone('0021671000000'));
         $this->assertTrue(TnValidation::phone('+21671000000'));
+        $this->assertTrue(TnValidation::phone('0021622000000'));
+        $this->assertTrue(TnValidation::phone('0021698000000'));
+        $this->assertTrue(TnValidation::phone('0021651000000'));
+        $this->assertTrue(TnValidation::phone('+21640000000'));
         $this->assertTrue(TnValidation::phone('71000000'));
         $this->assertTrue(TnValidation::phone('70999999'));
+        $this->assertTrue(TnValidation::phone('22000000'));
+        $this->assertTrue(TnValidation::phone('98999999'));
+        $this->assertTrue(TnValidation::phone('98999999'));
+        $this->assertTrue(TnValidation::phone('4012345678'));       
         $this->assertFalse(TnValidation::phone('21671000000'));
-        $this->assertFalse(TnValidation::phone('+0021671000000'));
-        $this->assertFalse(TnValidation::phone('22000000'));
+        $this->assertFalse(TnValidation::phone('+00216'));
+        $this->assertFalse(TnValidation::phone('0021398000000'));
+        $this->assertFalse(TnValidation::phone('+21630000000'));
         $this->assertFalse(TnValidation::phone('71 000 000'));
         $this->assertFalse(TnValidation::phone('7100000'));
         $this->assertFalse(TnValidation::phone('710000000'));
-        $this->assertFalse(TnValidation::phone(true));
+        $this->assertFalse(TnValidation::phone('60000000'));
+        $this->assertFalse(TnValidation::phone('9899999'));
+        $this->assertFalse(TnValidation::phone('989999999'));
+        $this->assertFalse(TnValidation::phone('004012345678'));
+        $this->assertFalse(TnValidation::phone(false));
         $this->assertFalse(TnValidation::phone('abcdef'));
-    }
-    /**
-     * test the mobile method of TnValidation
-     *
-     * @return void
-     */
-    public function testMobile()
-    {
-        $this->assertTrue(TnValidation::mobile('0021622000000'));
-        $this->assertTrue(TnValidation::mobile('0021698000000'));
-        $this->assertTrue(TnValidation::mobile('0021651000000'));
-        $this->assertTrue(TnValidation::mobile('+21640000000'));
-        $this->assertTrue(TnValidation::mobile('22000000'));
-        $this->assertTrue(TnValidation::mobile('98999999'));
-        $this->assertTrue(TnValidation::mobile('98999999'));
-        $this->assertTrue(TnValidation::mobile('4012345678'));
-        $this->assertFalse(TnValidation::mobile('+0021622000000'));
-        $this->assertFalse(TnValidation::mobile('0021398000000'));
-        $this->assertFalse(TnValidation::mobile('0021671000000'));
-        $this->assertFalse(TnValidation::mobile('+21630000000'));
-        $this->assertFalse(TnValidation::mobile('60000000'));
-        $this->assertFalse(TnValidation::mobile('9899999'));
-        $this->assertFalse(TnValidation::mobile('989999999'));
-        $this->assertFalse(TnValidation::mobile('004012345678'));
-        $this->assertFalse(TnValidation::mobile(false));
-        $this->assertFalse(TnValidation::mobile('abcdef'));
     }
     /**
      * test the postal method of TnValidation

--- a/tests/TestCase/Validation/TnValidationTest.php
+++ b/tests/TestCase/Validation/TnValidationTest.php
@@ -42,7 +42,7 @@ class TnValidationTest extends TestCase
         $this->assertTrue(TnValidation::phone('22000000'));
         $this->assertTrue(TnValidation::phone('98999999'));
         $this->assertTrue(TnValidation::phone('98999999'));
-        $this->assertTrue(TnValidation::phone('412345678'));       
+        $this->assertTrue(TnValidation::phone('41234567'));       
         $this->assertFalse(TnValidation::phone('21671000000'));
         $this->assertFalse(TnValidation::phone('+00216'));
         $this->assertFalse(TnValidation::phone('0021398000000'));

--- a/tests/TestCase/Validation/TnValidationTest.php
+++ b/tests/TestCase/Validation/TnValidationTest.php
@@ -57,6 +57,7 @@ class TnValidationTest extends TestCase
         $this->assertFalse(TnValidation::phone(false));
         $this->assertFalse(TnValidation::phone('abcdef'));
     }
+
     /**
      * test the postal method of TnValidation
      *
@@ -82,6 +83,7 @@ class TnValidationTest extends TestCase
         $this->assertFalse(TnValidation::postal('10'));
         $this->assertFalse(TnValidation::postal(true));
     }
+
     /**
      * test the personId method of TnValidation
      *

--- a/tests/TestCase/Validation/TnValidationTest.php
+++ b/tests/TestCase/Validation/TnValidationTest.php
@@ -42,7 +42,7 @@ class TnValidationTest extends TestCase
         $this->assertTrue(TnValidation::phone('22000000'));
         $this->assertTrue(TnValidation::phone('98999999'));
         $this->assertTrue(TnValidation::phone('98999999'));
-        $this->assertTrue(TnValidation::phone('41234567'));       
+        $this->assertTrue(TnValidation::phone('41234567'));
         $this->assertFalse(TnValidation::phone('21671000000'));
         $this->assertFalse(TnValidation::phone('+00216'));
         $this->assertFalse(TnValidation::phone('0021398000000'));


### PR DESCRIPTION
Fix dual forms and the names of the Gregorian months.

- In Algeria and Tunisia are based on the French names of the months
- dual form, unlike some other arabic countries, end with "IN" (ين) instead of "AN" (ان).

Same po translation file can also be used for Algerian translation
source: http://www.aclweb.org/anthology/W15-3208