### PR TITLE
(NL) Update to CakePHP3 string template syntax

### DIFF
--- a/src/Locale/nl/cake.po
+++ b/src/Locale/nl/cake.po
@@ -17,8 +17,8 @@ msgid "Error"
 msgstr "Fout"
 
 #: Template/Error/error400.ctp:35
-msgid "The requested address %s was not found on this server."
-msgstr "Het opgegeven pad %s is niet gevonden op deze server."
+msgid "The requested address {0} was not found on this server."
+msgstr "Het opgegeven pad {0} is niet gevonden op deze server."
 
 #: Template/Error/error500.ctp:33
 msgid "An Internal Error Has Occurred"
@@ -147,12 +147,12 @@ msgid "today"
 msgstr "vandaag"
 
 #: I18n/RelativeTimeFormatter.php:370
-msgid "%s ago"
-msgstr "%s geleden"
+msgid "{0} ago"
+msgstr "{0} geleden"
 
 #: I18n/RelativeTimeFormatter.php:371
-msgid "on %s"
-msgstr "op %s"
+msgid "on {0}"
+msgstr "op {0}"
 
 #: I18n/RelativeTimeFormatter.php:47;126;316
 msgid "{0} year"
@@ -229,12 +229,12 @@ msgid "The provided value is invalid"
 msgstr "De opgegeven waarde is niet geldig"
 
 #: View/Helper/FormHelper.php:963
-msgid "New %s"
-msgstr "Nieuw %s"
+msgid "New {0}"
+msgstr "Nieuw {0}"
 
 #: View/Helper/FormHelper.php:966
-msgid "Edit %s"
-msgstr "Wijzig %s"
+msgid "Edit {0}"
+msgstr "Wijzig {0}"
 
 #: View/Helper/FormHelper.php:1812
 msgid "Submit"


### PR DESCRIPTION
`{0}` instead of `%s` which at least for me did not work anymore when calling `<?= __d('cake', 'The requested address {0} was not found on this server.', "<strong>'{$url}'</strong>") ?>` (default cakephp/app error404.ctp template)