### PR TITLE
Deprecate the invalid personId() method for Poland.

### DIFF
--- a/src/Validation/PlValidation.php
+++ b/src/Validation/PlValidation.php
@@ -33,13 +33,28 @@ class PlValidation extends LocalizedValidation
     }
 
     /**
-     * Checks a social security number (NIP) for Poland.
+     * Checks a VAT identification number (NIP) for Poland.
+     *
+     * Note: the method name is misleading. In order to validate Person ID (PESEL) please use `pesel()` method instead.
+     *
+     * @param string $check Value to check
+     * @return bool Success.
+     * @deprecated 3.3.2 This method does not validate Polish Person ID and will be changed in the next major version.
+     * To validate Person ID (PESEL) please use `pesel()` method instead.
+     */
+    public static function personId($check)
+    {
+        return static::nip($check);
+    }
+
+    /**
+     * Checks a VAT identification number (NIP) for Poland.
      *
      * @param string $check Value to check
      * @return bool Success.
      * @link http://pl.wikipedia.org/wiki/NIP
      */
-    public static function personId($check)
+    public static function nip($check)
     {
         $pattern = '/^([0-9]{3}-[0-9]{3}-[0-9]{2}-[0-9]{2})|([0-9]{3}-[0-9]{2}-[0-9]{2}-[0-9]{3})|([0-9]{10})$/';
         if (!preg_match($pattern, $check)) {

--- a/tests/TestCase/Validation/PlValidationTest.php
+++ b/tests/TestCase/Validation/PlValidationTest.php
@@ -37,18 +37,18 @@ class PlValidationTest extends TestCase
     }
 
     /**
-     * test the ssn method of PlValidation
+     * test the nip method of PlValidation
      *
      * @return void
      */
-    public function testSsn()
+    public function testNip()
     {
-        $this->assertTrue(PlValidation::personId('768-000-24-66'));
-        $this->assertTrue(PlValidation::personId('768-00-02-466'));
-        $this->assertTrue(PlValidation::personId('7680002466'));
-        $this->assertFalse(PlValidation::personId('768-000-24-65'));
-        $this->assertFalse(PlValidation::personId('769-000-24-66'));
-        $this->assertFalse(PlValidation::personId('7680002566'));
+        $this->assertTrue(PlValidation::nip('768-000-24-66'));
+        $this->assertTrue(PlValidation::nip('768-00-02-466'));
+        $this->assertTrue(PlValidation::nip('7680002466'));
+        $this->assertFalse(PlValidation::nip('768-000-24-65'));
+        $this->assertFalse(PlValidation::nip('769-000-24-66'));
+        $this->assertFalse(PlValidation::nip('7680002566'));
     }
 
     /**


### PR DESCRIPTION
NIP is not a polish social security number nor a person ID. It's a number given to companies that pay taxes (historically it was also given to natural persons but currently PESEL is sufficient).  It's closest equivalent is a VAT identification number.

Actual Polish security/person ID is PESEL.

I deprecated the incorrect method and added `nip()` method for NIP validation. In the future this method behavior can be changed to validate PESEL numbers.

Refs https://github.com/cakephp/localized/pull/178#discussion_r152950534