### PR TITLE
Implement methods to validate date and decimal on localized form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=7.2",
-        "cakephp/cakephp": "^4.0.0"
+        "cakephp/cakephp": "^4.1.0"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^4.0",

--- a/src/Validation/AtValidation.php
+++ b/src/Validation/AtValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class AtValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'de_AT';
+
+    /**
      * Checks a postal code.
      *
      * @param string $check The value to check.

--- a/src/Validation/AuValidation.php
+++ b/src/Validation/AuValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class AuValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'en_AU';
+
+    /**
      * Checks a postal code for Australia.
      *
      * @param string $check The value to check.

--- a/src/Validation/BdValidation.php
+++ b/src/Validation/BdValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class BdValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'bn_BD';
+
+    /**
      * Checks a postal code.
      *
      * @param string $check The value to check.

--- a/src/Validation/BeValidation.php
+++ b/src/Validation/BeValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class BeValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'nl_BE';
+
+    /**
      * Checks a postal code for Belgium.
      *
      * @param string $check The value to check.

--- a/src/Validation/BrValidation.php
+++ b/src/Validation/BrValidation.php
@@ -28,7 +28,7 @@ class BrValidation extends LocalizedValidation
      *
      * @var string
      */
-    protected static $_validationLocale = 'pt_BR';
+    protected static $validationLocale = 'pt_BR';
 
     /**
      * Checks a phone number for Brazil.

--- a/src/Validation/BrValidation.php
+++ b/src/Validation/BrValidation.php
@@ -23,6 +23,14 @@ namespace Cake\Localized\Validation;
 class BrValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $_validationLocale = 'pt_BR';
+
+    /**
      * Checks a phone number for Brazil.
      *
      * @param string $check The value to check.

--- a/src/Validation/CaValidation.php
+++ b/src/Validation/CaValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class CaValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'en_CA';
+
+    /**
      * Checks a postal code for Canada.
      *
      * @param string $check The value to check.

--- a/src/Validation/ChValidation.php
+++ b/src/Validation/ChValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class ChValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'de_CH';
+
+    /**
      * Checks a postal code for Switzerland & Liechtenstein
      *
      * @param string $check The value to check.

--- a/src/Validation/CnValidation.php
+++ b/src/Validation/CnValidation.php
@@ -23,6 +23,14 @@ namespace Cake\Localized\Validation;
 class CnValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'zh_CN';
+
+    /**
      * Checks phone numbers for The Peoples Republic of China (mainland)
      *
      * It is not a strict rule and should cover almost all legal phone numbers.

--- a/src/Validation/CzValidation.php
+++ b/src/Validation/CzValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class CzValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'cs_CZ';
+
+    /**
      * Checks a postal code for Czech Republic
      *
      * @param string $check The value to check.

--- a/src/Validation/DeValidation.php
+++ b/src/Validation/DeValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class DeValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'de_DE';
+
+    /**
      * Checks a postal code for Germany.
      *
      * @param string $check The value to check.

--- a/src/Validation/DkValidation.php
+++ b/src/Validation/DkValidation.php
@@ -23,6 +23,14 @@ namespace Cake\Localized\Validation;
 class DkValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'da_DK';
+
+    /**
      * Checks a social security number for Denmark.
      *
      * @param string $check The value to check.

--- a/src/Validation/EsValidation.php
+++ b/src/Validation/EsValidation.php
@@ -23,6 +23,14 @@ namespace Cake\Localized\Validation;
 class EsValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'es_ES';
+
+    /**
      * The list of allowed personId codes. Sorted as wee need them.
      *
      * @var string

--- a/src/Validation/FiValidation.php
+++ b/src/Validation/FiValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class FiValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'fi_FI';
+
+    /**
      * Checks a postal code for Finland.
      *
      * @param string $check The value to check.

--- a/src/Validation/FrValidation.php
+++ b/src/Validation/FrValidation.php
@@ -23,6 +23,14 @@ namespace Cake\Localized\Validation;
 class FrValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'fr_FR';
+
+    /**
      * Checks a phone number for France.
      *
      * @param string $check The value to check.

--- a/src/Validation/GbValidation.php
+++ b/src/Validation/GbValidation.php
@@ -23,6 +23,14 @@ use Cake\Http\Exception\NotImplementedException;
 class GbValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'en_GB';
+
+    /**
      * Checks a postal code for The United Kingdom
      *
      * @param string $check The value to check.

--- a/src/Validation/HrValidation.php
+++ b/src/Validation/HrValidation.php
@@ -24,6 +24,14 @@ use Cake\Http\Exception\NotImplementedException;
 class HrValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'hr_HR';
+
+    /**
      * Checks a postal code for Croatia.
      *
      * @param string $check The value to check.

--- a/src/Validation/IdValidation.php
+++ b/src/Validation/IdValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class IdValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'id_ID';
+
+    /**
      * Checks a postal code for Indonesia.
      *
      * @param string $check The value to check.

--- a/src/Validation/InValidation.php
+++ b/src/Validation/InValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class InValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'en_IN';
+
+    /**
      * Validate postal code
      *
      * @param string $check The value to check.

--- a/src/Validation/IrValidation.php
+++ b/src/Validation/IrValidation.php
@@ -21,6 +21,14 @@ namespace Cake\Localized\Validation;
 class IrValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'fa_IR';
+
+    /**
      * Checks for Persian/Farsi characters and number an zero width non-joiner space.
      * Also accepts latin numbers preventing potential problem until PHP becomes fully unicode compatible.
      *

--- a/src/Validation/ItValidation.php
+++ b/src/Validation/ItValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class ItValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'it_IT';
+
+    /**
      * Checks a phone number for Italy.
      *
      * @param string $check The value to check.

--- a/src/Validation/JpValidation.php
+++ b/src/Validation/JpValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class JpValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'ja_JP';
+
+    /**
      * Checks a phone number for Japan.
      * Accepts the following format.
      * - 0311112222

--- a/src/Validation/LocalizedValidation.php
+++ b/src/Validation/LocalizedValidation.php
@@ -14,9 +14,65 @@ declare(strict_types=1);
  */
 namespace Cake\Localized\Validation;
 
+use Cake\I18n\Date;
+use Cake\I18n\I18n;
+use Cake\I18n\Number;
+
 /**
  * Localized Validation base class.
  */
 abstract class LocalizedValidation implements ValidationInterface
 {
+    /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $_validationLocale = 'en_US';
+
+    /**
+     * Checks a date string, from language specific format.
+     *
+     * @param string $string The value to check.
+     * @return bool Success.
+     */
+    public static function date(string $string): bool
+    {
+        $currentLocale = I18n::getLocale();
+        $needChange = ($currentLocale !== static::$_validationLocale);
+        if ($needChange) {
+            I18n::setLocale(static::$_validationLocale);
+        }
+
+        $isValid = Date::parseDate($string) !== null;
+
+        if ($needChange) {
+            I18n::setLocale($currentLocale);
+        }
+
+        return $isValid;
+    }
+
+    /**
+     * Checks a date and time string, from language specific format.
+     *
+     * @param string $string The value to check.
+     * @return bool Success.
+     */
+    public static function dateTime(string $string): bool
+    {
+        return Date::parseDateTime($string) !== null;
+    }
+
+    /**
+     * Checks a decimal number, from language specific format.
+     *
+     * @param string $string The value to check.
+     * @return bool Success.
+     */
+    public static function decimal(string $string): bool
+    {
+        return Number::parseFloat($string) !== false;
+    }
 }

--- a/src/Validation/LocalizedValidation.php
+++ b/src/Validation/LocalizedValidation.php
@@ -29,7 +29,7 @@ abstract class LocalizedValidation implements ValidationInterface
      *
      * @var string
      */
-    protected static $_validationLocale = 'en_US';
+    protected static $validationLocale = 'en_US';
 
     /**
      * Checks a date string, from language specific format.
@@ -40,15 +40,24 @@ abstract class LocalizedValidation implements ValidationInterface
     public static function date(string $string): bool
     {
         $currentLocale = I18n::getLocale();
-        $needChange = ($currentLocale !== static::$_validationLocale);
+        $needChange = ($currentLocale !== static::$validationLocale);
         if ($needChange) {
-            I18n::setLocale(static::$_validationLocale);
+            I18n::setLocale(static::$validationLocale);
+        }
+
+        $currentLenient = Date::lenientParsingEnabled();
+        if ($currentLenient) {
+            Date::disableLenientParsing();
         }
 
         $isValid = Date::parseDate($string) !== null;
 
         if ($needChange) {
             I18n::setLocale($currentLocale);
+        }
+
+        if ($currentLenient) {
+            Date::enableLenientParsing();
         }
 
         return $isValid;
@@ -62,7 +71,28 @@ abstract class LocalizedValidation implements ValidationInterface
      */
     public static function dateTime(string $string): bool
     {
-        return Date::parseDateTime($string) !== null;
+        $currentLocale = I18n::getLocale();
+        $needChange = ($currentLocale !== static::$validationLocale);
+        if ($needChange) {
+            I18n::setLocale(static::$validationLocale);
+        }
+
+        $currentLenient = Date::lenientParsingEnabled();
+        if ($currentLenient) {
+            Date::disableLenientParsing();
+        }
+
+        $isValid = Date::parseDateTime($string) !== null;
+
+        if ($needChange) {
+            I18n::setLocale($currentLocale);
+        }
+
+        if ($currentLenient) {
+            Date::enableLenientParsing();
+        }
+
+        return $isValid;
     }
 
     /**

--- a/src/Validation/LtValidation.php
+++ b/src/Validation/LtValidation.php
@@ -21,6 +21,14 @@ namespace Cake\Localized\Validation;
 class LtValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'lt_LT';
+
+    /**
      * Checks a phone number for the Lithuania.
      *
      * @param string $check The value to check.

--- a/src/Validation/LvValidation.php
+++ b/src/Validation/LvValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class LvValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'lv_LV';
+
+    /**
      * Checks a postal code for Latvia.
      *
      * @param string $check The value to check.

--- a/src/Validation/MxValidation.php
+++ b/src/Validation/MxValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class MxValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'es_MX';
+
+    /**
      * Checks a phone number for Mexico.
      *
      * @param string $check The value to check.

--- a/src/Validation/NlValidation.php
+++ b/src/Validation/NlValidation.php
@@ -21,6 +21,14 @@ namespace Cake\Localized\Validation;
 class NlValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'nl_NL';
+
+    /**
      * Checks a phone number for The Netherlands
      *
      * @param string $check The value to check.

--- a/src/Validation/NoValidation.php
+++ b/src/Validation/NoValidation.php
@@ -23,6 +23,14 @@ namespace Cake\Localized\Validation;
 class NoValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'nb_NO';
+
+    /**
      * Checks date of birth formal format for Norway (dd.mm.yyyy),
      * afterwards checks if is a valid gregorian calendar date.
      *

--- a/src/Validation/PlValidation.php
+++ b/src/Validation/PlValidation.php
@@ -21,6 +21,14 @@ namespace Cake\Localized\Validation;
 class PlValidation extends \Cake\Localized\Validation\LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'pl_PL';
+
+    /**
      * Checks a postal code for Poland.
      *
      * @param string $check Value to check

--- a/src/Validation/PtValidation.php
+++ b/src/Validation/PtValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class PtValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'pt_PT';
+
+    /**
      * Checks a postal code for Portugal.
      *
      * @param string $check The value to check.

--- a/src/Validation/RoValidation.php
+++ b/src/Validation/RoValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class RoValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'ro_RO';
+
+    /**
      * Checks postal codes for Romania
      *
      * @param string $check The value to check.

--- a/src/Validation/RsValidation.php
+++ b/src/Validation/RsValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class RsValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'cs_RS';
+
+    /**
      * Checks a postal code (Poštanski broj) for Serbia.
      *
      * @param string $check The value to check.

--- a/src/Validation/RuValidation.php
+++ b/src/Validation/RuValidation.php
@@ -23,6 +23,14 @@ namespace Cake\Localized\Validation;
 class RuValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'ru_RU';
+
+    /**
      * Checks a postal code for Russia
      *
      * @param string $check The value to check.

--- a/src/Validation/SkValidation.php
+++ b/src/Validation/SkValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class SkValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'sk_SK';
+
+    /**
      * Checks a postal code for Slovakia.
      *
      * @param string $check The value to check.

--- a/src/Validation/TnValidation.php
+++ b/src/Validation/TnValidation.php
@@ -23,6 +23,14 @@ namespace Cake\Localized\Validation;
 class TnValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'ar_TN';
+
+    /**
      * Checks a phone number for Tunisia.
      *
      * @param string $check The value to check.

--- a/src/Validation/TrValidation.php
+++ b/src/Validation/TrValidation.php
@@ -25,6 +25,14 @@ use Cake\Http\Exception\NotImplementedException;
 class TrValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'tr_TR';
+
+    /**
      * Checks a postal code for Turkey.
      *
      * @param string $check The value to check.

--- a/src/Validation/TwValidation.php
+++ b/src/Validation/TwValidation.php
@@ -23,6 +23,14 @@ namespace Cake\Localized\Validation;
 class TwValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'zh_TW';
+
+    /**
      * Checks a phone number for Taiwan.
      *
      * @param string $check The value to check.

--- a/src/Validation/UaValidation.php
+++ b/src/Validation/UaValidation.php
@@ -23,6 +23,14 @@ namespace Cake\Localized\Validation;
 class UaValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'uk_UA';
+
+    /**
      * Checks a postal (zip) code for Ukraine
      *
      * @example 85111; 01996; 65000;

--- a/src/Validation/UsValidation.php
+++ b/src/Validation/UsValidation.php
@@ -21,6 +21,14 @@ namespace Cake\Localized\Validation;
 class UsValidation extends LocalizedValidation
 {
     /**
+     * Define locale to be used by that localized
+     * validation set
+     *
+     * @var string
+     */
+    protected static $validationLocale = 'en_US';
+
+    /**
      * Checks a phone number for The United States
      *
      * @param string $check The value to check.

--- a/src/Validation/ValidationInterface.php
+++ b/src/Validation/ValidationInterface.php
@@ -42,4 +42,28 @@ interface ValidationInterface
      * @return bool Success.
      */
     public static function personId(string $string): bool;
+
+    /**
+     * Checks a date string, from language specific format.
+     *
+     * @param string $string The value to check.
+     * @return bool Success.
+     */
+    public static function date(string $string): bool;
+
+    /**
+     * Checks a date and time string, from language specific format.
+     *
+     * @param string $string The value to check.
+     * @return bool Success.
+     */
+    public static function dateTime(string $string): bool;
+
+    /**
+     * Checks a decimal number, from language specific format.
+     *
+     * @param string $string The value to check.
+     * @return bool Success.
+     */
+    public static function decimal(string $string): bool;
 }

--- a/tests/TestCase/Validation/BrValidationTest.php
+++ b/tests/TestCase/Validation/BrValidationTest.php
@@ -190,4 +190,23 @@ class BrValidationTest extends TestCase
         $this->assertFalse(BrValidation::cns('9021 6194 0000'));
         $this->assertFalse(BrValidation::cns(['12345678909']));
     }
+
+    /**
+     * test the date method of BrValidation
+     *
+     * @return void
+     */
+    public function testDate()
+    {
+        $this->assertTrue(BrValidation::date('01/01/2020'));
+        $this->assertTrue(BrValidation::date('12/11/2019'));
+        $this->assertTrue(BrValidation::date('21/04/1940'));
+        $this->assertTrue(BrValidation::date('1/3/20'));
+        $this->assertTrue(BrValidation::date('25-12-2000'));
+
+        $this->assertFalse(BrValidation::date('04/21/1980'));
+        $this->assertFalse(BrValidation::date('2000-12-25'));
+        $this->assertFalse(BrValidation::date('2019/11/12'));
+        $this->assertFalse(BrValidation::date('2040/25/12'));
+    }
 }

--- a/tests/TestCase/Validation/BrValidationTest.php
+++ b/tests/TestCase/Validation/BrValidationTest.php
@@ -202,9 +202,9 @@ class BrValidationTest extends TestCase
         $this->assertTrue(BrValidation::date('12/11/2019'));
         $this->assertTrue(BrValidation::date('21/04/1940'));
         $this->assertTrue(BrValidation::date('1/3/20'));
-        $this->assertTrue(BrValidation::date('25-12-2000'));
 
-        $this->assertFalse(BrValidation::date('04/21/1980'));
+        $this->assertFalse(BrValidation::date('25-12-2000'), 'BR date accept only slash as separator');
+        $this->assertFalse(BrValidation::date('04/21/1980'), 'BR date accept only day/month/year sequence');
         $this->assertFalse(BrValidation::date('2000-12-25'));
         $this->assertFalse(BrValidation::date('2019/11/12'));
         $this->assertFalse(BrValidation::date('2040/25/12'));

--- a/tests/TestCase/Validation/UsValidationTest.php
+++ b/tests/TestCase/Validation/UsValidationTest.php
@@ -115,4 +115,23 @@ class UsValidationTest extends TestCase
         $this->assertFalse(UsValidation::personId('111-33-333'));
         $this->assertTrue(UsValidation::personId('111-33-4333'));
     }
+
+    /**
+     * test the date method of UsValidation
+     *
+     * @return void
+     */
+    public function testDate()
+    {
+        $this->assertTrue(UsValidation::date('01/01/2020'));
+        $this->assertTrue(UsValidation::date('12/11/2019'));
+        $this->assertTrue(UsValidation::date('04/21/1980'));
+        $this->assertTrue(UsValidation::date('1/3/20'));
+
+        $this->assertFalse(UsValidation::date('25-12-2000'));
+        $this->assertFalse(UsValidation::date('21/04/1940'));
+        $this->assertFalse(UsValidation::date('2000-12-25'));
+        $this->assertFalse(UsValidation::date('2019/11/12'));
+        $this->assertFalse(UsValidation::date('2040/25/12'));
+    }
 }

--- a/tests/TestCase/Validation/UsValidationTest.php
+++ b/tests/TestCase/Validation/UsValidationTest.php
@@ -128,6 +128,7 @@ class UsValidationTest extends TestCase
         $this->assertTrue(UsValidation::date('04/21/1980'));
         $this->assertTrue(UsValidation::date('1/3/20'));
 
+        $this->assertFalse(UsValidation::date('1-3-2020'), 'US date only accept slash as separator');
         $this->assertFalse(UsValidation::date('25-12-2000'));
         $this->assertFalse(UsValidation::date('21/04/1940'));
         $this->assertFalse(UsValidation::date('2000-12-25'));


### PR DESCRIPTION
Resolve #186 

Using `\Cake\I18n` subsystem, validate string of date/datetim or decimal number from your localized form.