### PR TITLE
Using assertSame and fix coding style via PHPCS

### DIFF
--- a/src/Validation/BrValidation.php
+++ b/src/Validation/BrValidation.php
@@ -193,7 +193,7 @@ class BrValidation extends LocalizedValidation
 
         $cns = preg_replace('/[^0-9]/', '', $cns);
 
-        if (preg_match("/[1-2]\\d{10}00[0-1]\\d/", $cns) || preg_match("/[7-9]\\d{14}/", $cns)) {
+        if (preg_match('/[1-2]\\d{10}00[0-1]\\d/', $cns) || preg_match('/[7-9]\\d{14}/', $cns)) {
             $len = strlen($cns);
             $soma = 0;
             for ($i = 0; $i < $len; $i++) {

--- a/src/Validation/LtValidation.php
+++ b/src/Validation/LtValidation.php
@@ -28,7 +28,7 @@ class LtValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        $pattern = "/^(([\\+]?370)|(8))[\\s-]?\\(?\\d{2,3}\\)?[\\s-]?(\\d{2}[\\s-]?){2}?\\d{1,2}\$/";
+        $pattern = '/^(([\+]?370)|(8))[\s-]?\(?\d{2,3}\)?[\s-]?(\d{2}[\s-]?){2}?\d{1,2}$/';
 
         return (bool)preg_match($pattern, $check);
     }

--- a/tests/TestCase/Validation/FiValidationTest.php
+++ b/tests/TestCase/Validation/FiValidationTest.php
@@ -109,7 +109,7 @@ class FiValidationTest extends TestCase
      */
     public function testPersonId($item, $assert)
     {
-        $this->assertEquals($assert, FiValidation::personId($item));
+        $this->assertSame($assert, FiValidation::personId($item));
     }
 
     /**
@@ -122,7 +122,7 @@ class FiValidationTest extends TestCase
      */
     public function testPostal($item, $assert)
     {
-        $this->assertEquals($assert, FiValidation::postal($item));
+        $this->assertSame($assert, FiValidation::postal($item));
     }
 
     /**

--- a/tests/TestCase/Validation/LvValidationTest.php
+++ b/tests/TestCase/Validation/LvValidationTest.php
@@ -51,6 +51,6 @@ class LvValidationTest extends TestCase
      */
     public function testPersonId($item, $assert)
     {
-        $this->assertEquals($assert, LvValidation::personId($item));
+        $this->assertSame($assert, LvValidation::personId($item));
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,7 +12,7 @@ $findRoot = function ($root) {
         }
     } while ($root !== $lastRoot);
 
-    throw new Exception("Cannot find the root of the application, unable to run tests");
+    throw new Exception('Cannot find the root of the application, unable to run tests');
 };
 $root = $findRoot(__FILE__);
 unset($findRoot);


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make expected strict to assert the result.
- Fix coding style with `PHP_CodeSniffer` tool. The coding style errors are as follows:

```
FILE: ...n-source-contributions/localized/src/Validation/LtValidation.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 31 | ERROR | [x] Use single instead of double quotes for simple
    |       |     strings.
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
FILE: ...is/build/open-source-contributions/localized/tests/bootstrap.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 15 | ERROR | [x] Use single instead of double quotes for simple
    |       |     strings.
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
FILE: ...n-source-contributions/localized/src/Validation/BrValidation.php
----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 1 LINE
----------------------------------------------------------------------
 196 | ERROR | [x] Use single instead of double quotes for simple
     |       |     strings.
 196 | ERROR | [x] Use single instead of double quotes for simple
     |       |     strings.
----------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------

```