### PR TITLE
Fix up exception messages.

### DIFF
--- a/src/Validation/AtValidation.php
+++ b/src/Validation/AtValidation.php
@@ -54,7 +54,7 @@ class AtValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**
@@ -66,6 +66,6 @@ class AtValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/AuValidation.php
+++ b/src/Validation/AuValidation.php
@@ -68,6 +68,6 @@ class AuValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/BdValidation.php
+++ b/src/Validation/BdValidation.php
@@ -54,7 +54,7 @@ class BdValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**
@@ -66,6 +66,6 @@ class BdValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/BeValidation.php
+++ b/src/Validation/BeValidation.php
@@ -54,7 +54,7 @@ class BeValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**
@@ -65,6 +65,6 @@ class BeValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/CaValidation.php
+++ b/src/Validation/CaValidation.php
@@ -54,7 +54,7 @@ class CaValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**
@@ -65,6 +65,6 @@ class CaValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/ChValidation.php
+++ b/src/Validation/ChValidation.php
@@ -55,7 +55,7 @@ class ChValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**
@@ -67,6 +67,6 @@ class ChValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/CzValidation.php
+++ b/src/Validation/CzValidation.php
@@ -54,7 +54,7 @@ class CzValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**
@@ -66,6 +66,6 @@ class CzValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/DeValidation.php
+++ b/src/Validation/DeValidation.php
@@ -102,6 +102,6 @@ class DeValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/FiValidation.php
+++ b/src/Validation/FiValidation.php
@@ -55,7 +55,7 @@ class FiValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**

--- a/src/Validation/GbValidation.php
+++ b/src/Validation/GbValidation.php
@@ -52,7 +52,7 @@ class GbValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**
@@ -64,6 +64,6 @@ class GbValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/HrValidation.php
+++ b/src/Validation/HrValidation.php
@@ -53,7 +53,7 @@ class HrValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**
@@ -65,6 +65,6 @@ class HrValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/IdValidation.php
+++ b/src/Validation/IdValidation.php
@@ -67,7 +67,7 @@ class IdValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**
@@ -79,6 +79,6 @@ class IdValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/InValidation.php
+++ b/src/Validation/InValidation.php
@@ -67,6 +67,6 @@ class InValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/ItValidation.php
+++ b/src/Validation/ItValidation.php
@@ -106,6 +106,6 @@ class ItValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/JpValidation.php
+++ b/src/Validation/JpValidation.php
@@ -158,6 +158,6 @@ class JpValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/LvValidation.php
+++ b/src/Validation/LvValidation.php
@@ -42,7 +42,7 @@ class LvValidation extends LocalizedValidation
      */
     public static function postal(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**
@@ -54,7 +54,7 @@ class LvValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**

--- a/src/Validation/MxValidation.php
+++ b/src/Validation/MxValidation.php
@@ -67,6 +67,6 @@ class MxValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/PtValidation.php
+++ b/src/Validation/PtValidation.php
@@ -54,7 +54,7 @@ class PtValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**
@@ -66,6 +66,6 @@ class PtValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/RoValidation.php
+++ b/src/Validation/RoValidation.php
@@ -54,7 +54,7 @@ class RoValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**
@@ -66,6 +66,6 @@ class RoValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/RsValidation.php
+++ b/src/Validation/RsValidation.php
@@ -128,6 +128,6 @@ class RsValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/SkValidation.php
+++ b/src/Validation/SkValidation.php
@@ -54,7 +54,7 @@ class SkValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**
@@ -66,6 +66,6 @@ class SkValidation extends LocalizedValidation
      */
     public static function personId(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 }

--- a/src/Validation/TrValidation.php
+++ b/src/Validation/TrValidation.php
@@ -85,7 +85,7 @@ class TrValidation extends LocalizedValidation
      */
     public static function phone(string $check): bool
     {
-        throw new NotImplementedException(__d('localized', '%s Not implemented yet.'));
+        throw new NotImplementedException(__d('localized', '`{0}()` Not implemented yet.', __METHOD__));
     }
 
     /**

--- a/tests/TestCase/Validation/TrValidationTest.php
+++ b/tests/TestCase/Validation/TrValidationTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
  */
 namespace Cake\Localized\Test\TestCase\Validation;
 
+use Cake\Http\Exception\NotImplementedException;
 use Cake\Localized\Validation\TrValidation;
 use Cake\TestSuite\TestCase;
 
@@ -55,5 +56,16 @@ class TrValidationTest extends TestCase
         $this->assertFalse(TrValidation::personId('31216166930'));
         $this->assertFalse(TrValidation::personId('01216166930'));
         $this->assertFalse(TrValidation::personId('31216166931'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testPhone(): void
+    {
+        $this->expectException(NotImplementedException::class);
+        $this->expectExceptionMessage('`Cake\Localized\Validation\TrValidation::phone()` Not implemented yet.');
+
+        TrValidation::phone('');
     }
 }


### PR DESCRIPTION
No one noticed this for years?

Now fixed from literal output of

    %s Not implemented yet.

to e.g.

    `Cake\Localized\Validation\TrValidation::phone()` Not implemented yet.
    
See https://sandbox.dereuromark.de/sandbox/localized/basic?code=HR&method=personId