### PR TITLE
Fix CI failures on 5.x (PHP 8.3 regex, phpcs, phpstan)

### DIFF
--- a/src/Validation/FiValidation.php
+++ b/src/Validation/FiValidation.php
@@ -85,7 +85,6 @@ class FiValidation extends LocalizedValidation
         }
         $list = array_values($list);
 
-        /** @phpstan-ignore-next-line */
         return $check[strlen($check) - 1] === $list[(int)(substr($check, 0, 6) . substr($check, 7, 3)) % 31];
     }
 

--- a/src/Validation/IrValidation.php
+++ b/src/Validation/IrValidation.php
@@ -50,7 +50,7 @@ class IrValidation extends LocalizedValidation
      */
     public static function numeric(string $check): bool
     {
-        $pattern = '/[^\x{06F0}-\x{06F9}\x]+/u';
+        $pattern = '/[^\x{06F0}-\x{06F9}]+/u';
 
         return !preg_match($pattern, $check);
     }

--- a/src/Validation/RsValidation.php
+++ b/src/Validation/RsValidation.php
@@ -78,7 +78,7 @@ class RsValidation extends LocalizedValidation
         return (bool)preg_match($pattern, $check);
     }
 
-    // @codingStandardsIgnoreStart
+    // phpcs:disable PSR1.Methods.CamelCapsMethodName
 
     /**
      * Checks an address code (Adresni kod) for Serbia.
@@ -104,7 +104,7 @@ class RsValidation extends LocalizedValidation
         return static::postal($check);
     }
 
-    // @codingStandardsIgnoreEnd
+    // phpcs:enable PSR1.Methods.CamelCapsMethodName
 
     /**
      * Checks Unique Master Citizen Numbers (JMBG) for Serbia.


### PR DESCRIPTION
CI is red on `5.x`, which also blocks unrelated PRs such as the Dependabot `actions/checkout` bump (#279). Three independent failures:

**1. PHP 8.3+ test failure - `IrValidation::numeric()`**
The regex `/[^\x{06F0}-\x{06F9}\x]+/u` contains a stray `\x` with no hex digits. PCRE2 (PHP 8.3+) rejects it with `Compilation failed: digits missing after \x`, so `preg_match()` returns `false` and every input is treated as valid. Removing the stray `\x` restores the intended "anything that is not a Persian digit" class.

**2. CodeSniffer failure - `RsValidation`**
The deprecated `// @codingStandardsIgnoreStart` / `End` comment markers are no longer honored by the current sniffer, so the intentionally-kept snake_case deprecated methods (`address_code`, `postal_number`) get flagged. Switched to the modern `// phpcs:disable PSR1.Methods.CamelCapsMethodName` / `enable`.

**3. PHPStan failure - `FiValidation`**
A stale `@phpstan-ignore-next-line` no longer matches any reported error (`No error to ignore is reported on line 89`). Removed it.

All 130 tests pass and phpcs is clean locally.
