### PR TITLE
CNPJ alphanumeric (Brasil)

### DIFF
--- a/src/Validation/BrValidation.php
+++ b/src/Validation/BrValidation.php
@@ -118,22 +118,22 @@ class BrValidation extends LocalizedValidation
         // sometimes the user submits a masked CNPJ
         if (preg_match('/^\d\d.\d\d\d.\d\d\d\/\d\d\d\d\-\d\d/', $check)) {
             $check = str_replace(['-', '.', '/'], '', $check);
-        } elseif (!ctype_digit($check)) {
+        } elseif (!ctype_alnum($check)) {
             return false;
         }
-
+        $charVal = fn(int $key) => ord($check[$key]) - 48;
         if (strlen($check) !== 14) {
             return false;
         }
-        $firstSum = ((int)$check[0] * 5) + ((int)$check[1] * 4) + ((int)$check[2] * 3) + ((int)$check[3] * 2) +
-            ((int)$check[4] * 9) + ((int)$check[5] * 8) + ((int)$check[6] * 7) + ((int)$check[7] * 6) +
-            ((int)$check[8] * 5) + ((int)$check[9] * 4) + ((int)$check[10] * 3) + ((int)$check[11] * 2);
+        $firstSum = ($charVal(0) * 5) + ($charVal(1) * 4) + ($charVal(2) * 3) + ($charVal(3) * 2) +
+            ($charVal(4) * 9) + ($charVal(5) * 8) + ($charVal(6) * 7) + ($charVal(7) * 6) +
+            ($charVal(8) * 5) + ($charVal(9) * 4) + ($charVal(10) * 3) + ($charVal(11) * 2);
 
         $firstVerificationDigit = $firstSum % 11 < 2 ? 0 : 11 - ($firstSum % 11);
 
-        $secondSum = ((int)$check[0] * 6) + ((int)$check[1] * 5) + ((int)$check[2] * 4) + ((int)$check[3] * 3) +
-            ((int)$check[4] * 2) + ((int)$check[5] * 9) + ((int)$check[6] * 8) + ((int)$check[7] * 7) +
-            ((int)$check[8] * 6) + ((int)$check[9] * 5) + ((int)$check[10] * 4) + ((int)$check[11] * 3) +
+        $secondSum = ($charVal(0) * 6) + ($charVal(1) * 5) + ($charVal(2) * 4) + ($charVal(3) * 3) +
+            ($charVal(4) * 2) + ($charVal(5) * 9) + ($charVal(6) * 8) + ($charVal(7) * 7) +
+            ($charVal(8) * 6) + ($charVal(9) * 5) + ($charVal(10) * 4) + ($charVal(11) * 3) +
             ((int)$check[12] * 2);
 
         $secondVerificationDigit = $secondSum % 11 < 2 ? 0 : 11 - ($secondSum % 11);

--- a/src/Validation/BrValidation.php
+++ b/src/Validation/BrValidation.php
@@ -114,7 +114,7 @@ class BrValidation extends LocalizedValidation
      */
     public static function cnpj(string $check): bool
     {
-        $check = trim($check);
+        $check = strtoupper(trim($check));
         // sometimes the user submits a masked CNPJ
         if (preg_match('/^\d\d.\d\d\d.\d\d\d\/\d\d\d\d\-\d\d/', $check)) {
             $check = str_replace(['-', '.', '/'], '', $check);

--- a/src/Validation/BrValidation.php
+++ b/src/Validation/BrValidation.php
@@ -114,7 +114,7 @@ class BrValidation extends LocalizedValidation
      */
     public static function cnpj(string $check): bool
     {
-        $check = strtoupper(trim($check));
+        $check = mb_strtoupper(trim($check));
         // sometimes the user submits a masked CNPJ
         if (preg_match('/^([A-Z0-9]{2}).([A-Z0-9]{3}).([A-Z0-9]{3})\/([A-Z0-9]{4})\-\d\d/', $check)) {
             $check = str_replace(['-', '.', '/'], '', $check);
@@ -122,7 +122,7 @@ class BrValidation extends LocalizedValidation
             return false;
         }
         $charVal = fn(int $key) => ord($check[$key]) - 48;
-        if (strlen($check) !== 14) {
+        if (mb_strlen($check) !== 14) {
             return false;
         }
         $firstSum = ($charVal(0) * 5) + ($charVal(1) * 4) + ($charVal(2) * 3) + ($charVal(3) * 2) +

--- a/src/Validation/BrValidation.php
+++ b/src/Validation/BrValidation.php
@@ -116,7 +116,7 @@ class BrValidation extends LocalizedValidation
     {
         $check = strtoupper(trim($check));
         // sometimes the user submits a masked CNPJ
-        if (preg_match('/^\d\d.\d\d\d.\d\d\d\/\d\d\d\d\-\d\d/', $check)) {
+        if (preg_match('/^([A-Z0-9]{2}).([A-Z0-9]{3}).([A-Z0-9]{3})\/([A-Z0-9]{4})\-\d\d/', $check)) {
             $check = str_replace(['-', '.', '/'], '', $check);
         } elseif (!ctype_alnum($check)) {
             return false;

--- a/tests/TestCase/Validation/BrValidationTest.php
+++ b/tests/TestCase/Validation/BrValidationTest.php
@@ -126,7 +126,14 @@ class BrValidationTest extends TestCase
         $this->assertTrue(BrValidation::personId('33.530.486/0001-29'));
 
         //Testing alphanumeric CNPJ
+        $this->assertFalse(BrValidation::cnpj('ABC123Z4000110'));
+        $this->assertFalse(BrValidation::cnpj('9AB5B5FF0001AB'));//Last two chars must be numeric
+
         $this->assertTrue(BrValidation::cnpj('XOXDNB0K000156'));
+        $this->assertTrue(BrValidation::cnpj('F9Z3AJUJ000108'));
+        $this->assertTrue(BrValidation::cnpj('f9z3AjUj000108'));//lowercase must work
+        $this->assertTrue(BrValidation::cnpj('NGZ9C1T4000145'));
+        $this->assertTrue(BrValidation::cnpj('12.ABC.345/01DE-35'));
 
         // Testing ssn
         $this->assertFalse(BrValidation::personId('04295165000133'));

--- a/tests/TestCase/Validation/BrValidationTest.php
+++ b/tests/TestCase/Validation/BrValidationTest.php
@@ -128,6 +128,8 @@ class BrValidationTest extends TestCase
         //Testing alphanumeric CNPJ
         $this->assertFalse(BrValidation::cnpj('ABC123Z4000110'));
         $this->assertFalse(BrValidation::cnpj('9AB5B5FF0001AB'));//Last two chars must be numeric
+        $this->assertFalse(BrValidation::cnpj('12.@BC.345/01#E-35'));//bad chars @#
+        $this->assertFalse(BrValidation::cnpj('XOX&@!B0K000156'));//Bad chars &@!
 
         $this->assertTrue(BrValidation::cnpj('XOXDNB0K000156'));
         $this->assertTrue(BrValidation::cnpj('F9Z3AJUJ000108'));

--- a/tests/TestCase/Validation/BrValidationTest.php
+++ b/tests/TestCase/Validation/BrValidationTest.php
@@ -127,6 +127,7 @@ class BrValidationTest extends TestCase
 
         //Testing alphanumeric CNPJ
         $this->assertFalse(BrValidation::cnpj('ABC123Z4000110'));
+        $this->assertFalse(BrValidation::cnpj('9AB5B5FF0001AB'));
         $this->assertFalse(BrValidation::cnpj('9AB5B5FF0001AB'));//Last two chars must be numeric
         $this->assertFalse(BrValidation::cnpj('12.@BC.345/01#E-35'));//bad chars @#
         $this->assertFalse(BrValidation::cnpj('XOX&@!B0K000156'));//Bad chars &@!
@@ -146,10 +147,13 @@ class BrValidationTest extends TestCase
         $this->assertFalse(BrValidation::personId('33.530.485/0001-29'));
         $this->assertFalse(BrValidation::personId('04.295.166/0001-01'));
         $this->assertFalse(BrValidation::personId('33.530.486/0001-30'));
+        $this->assertFalse(BrValidation::personId('ABC123Z4000110'));
         $this->assertTrue(BrValidation::personId('04295166000133'));
         $this->assertTrue(BrValidation::personId('33530486000129'));
         $this->assertTrue(BrValidation::personId('04.295.166/0001-33'));
         $this->assertTrue(BrValidation::personId('33.530.486/0001-29'));
+        $this->assertTrue(BrValidation::personId('NGZ9C1T4000145'));
+        $this->assertTrue(BrValidation::personId('12.ABC.345/01DE-35'));
 
         // Testing invalid input
         $this->assertFalse(BrValidation::personId('3712093712890371289073901287390812'));

--- a/tests/TestCase/Validation/BrValidationTest.php
+++ b/tests/TestCase/Validation/BrValidationTest.php
@@ -125,6 +125,9 @@ class BrValidationTest extends TestCase
         $this->assertTrue(BrValidation::personId('04.295.166/0001-33'));
         $this->assertTrue(BrValidation::personId('33.530.486/0001-29'));
 
+        //Testing alphanumeric CNPJ
+        $this->assertTrue(BrValidation::cnpj('XOXDNB0K000156'));
+
         // Testing ssn
         $this->assertFalse(BrValidation::personId('04295165000133'));
         $this->assertFalse(BrValidation::personId('33530485000129'));


### PR DESCRIPTION
Brazil has introduced an alphanumeric CNPJ format. This PR updates the plugin to recognize and process both the new alphanumeric format and the existing numeric format. The alphanumeric CNPJ will be assigned exclusively to new registrations starting in July 2026, for this reason we must accept both formats.
## What's included

- Updated CNPJ validation to support for alphanumeric characters
- Backward compatibility with numeric CNPJs
- New test coverage for alphanumeric format


Resources: 
https://www.legisweb.com.br/legislacao/?id=466532
https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/publicacoes/documentos-tecnicos/cnpj/manual-dv-cnpj.pdf/@@download/file